### PR TITLE
return status code in GetSObjectByExternalId, GetSObjectBySpecificExt…

### DIFF
--- a/force/api.go
+++ b/force/api.go
@@ -177,8 +177,8 @@ type RestAPI interface {
 	InsertSObject(in SObject) (resp *SObjectResponse, err error)
 	UpdateSObject(id string, in SObject) (err error)
 	DeleteSObject(id string, in SObject) (err error)
-	GetSObjectByExternalId(id string, fields []string, out SObject) (err error)
-	GetSObjectByspecificExternalType(id string, fields []string, specificExternalType string, out SObject) (err error)
+	GetSObjectByExternalId(id string, fields []string, out SObject) (statusCode int, err error)
+	GetSObjectByspecificExternalType(id string, fields []string, specificExternalType string, out SObject) (statusCode int, err error)
 	UpsertSObjectByExternalId(id string, in SObject) (statusCode int, resp *SObjectResponse, err error)
 	DeleteSObjectByExternalId(id string, in SObject) (err error)
 	GetInstanceURL() string
@@ -190,14 +190,15 @@ type RestAPI interface {
 func (forceApi *ForceApi) getApiResources() error {
 	uri := fmt.Sprintf(resourcesUri, forceApi.apiVersion)
 
-	return forceApi.Get(uri, nil, &forceApi.apiResources)
+	_, err := forceApi.Get(uri, nil, &forceApi.apiResources)
+	return err
 }
 
 func (forceApi *ForceApi) getApiSObjects() error {
 	uri := forceApi.apiResources[sObjectsKey]
 
 	list := &SObjectApiResponse{}
-	err := forceApi.Get(uri, nil, list)
+	_, err := forceApi.Get(uri, nil, list)
 	if err != nil {
 		return err
 	}
@@ -217,7 +218,7 @@ func (forceApi *ForceApi) getApiSObjectDescriptions() error {
 		uri := metaData.URLs[sObjectDescribeKey]
 
 		desc := &SObjectDescription{}
-		err := forceApi.Get(uri, nil, desc)
+		_, err := forceApi.Get(uri, nil, desc)
 		if err != nil {
 			return err
 		}

--- a/force/client.go
+++ b/force/client.go
@@ -20,9 +20,8 @@ const (
 
 // Get issues a GET to the specified path with the given params and put the
 // umarshalled (json) result in the third parameter
-func (forceApi *ForceApi) Get(path string, params url.Values, out interface{}) error {
-	_, err := forceApi.request("GET", path, params, nil, out)
-	return err
+func (forceApi *ForceApi) Get(path string, params url.Values, out interface{}) (int, error) {
+	return forceApi.request("GET", path, params, nil, out)
 }
 
 // Post issues a POST to the specified path with the given params and payload

--- a/force/limits.go
+++ b/force/limits.go
@@ -11,7 +11,7 @@ func (forceApi *ForceApi) GetLimits() (limits *Limits, err error) {
 	uri := forceApi.apiResources[limitsKey]
 
 	limits = &Limits{}
-	err = forceApi.Get(uri, nil, limits)
+	_, err = forceApi.Get(uri, nil, limits)
 
 	return
 }

--- a/force/query.go
+++ b/force/query.go
@@ -28,7 +28,7 @@ func (forceApi *ForceApi) Query(query string, out interface{}) (err error) {
 		"q": {query},
 	}
 
-	err = forceApi.Get(uri, params, out)
+	_, err = forceApi.Get(uri, params, out)
 
 	return
 }
@@ -43,13 +43,13 @@ func (forceApi *ForceApi) QueryAll(query string, out interface{}) (err error) {
 		"q": {query},
 	}
 
-	err = forceApi.Get(uri, params, out)
+	_, err = forceApi.Get(uri, params, out)
 
 	return
 }
 
 func (forceApi *ForceApi) QueryNext(uri string, out interface{}) (err error) {
-	err = forceApi.Get(uri, nil, out)
+	_, err = forceApi.Get(uri, nil, out)
 
 	return
 }

--- a/force/sobjects.go
+++ b/force/sobjects.go
@@ -41,7 +41,7 @@ func (forceApi *ForceApi) DescribeSObject(in SObject) (resp *SObjectDescription,
 		uri := sObjectMetaData.URLs[sObjectDescribeKey]
 
 		resp = &SObjectDescription{}
-		err = forceApi.Get(uri, nil, resp)
+		_, err = forceApi.Get(uri, nil, resp)
 		if err != nil {
 			return
 		}
@@ -78,7 +78,7 @@ func (forceApi *ForceApi) GetSObject(id string, fields []string, out SObject) (e
 		params.Add("fields", strings.Join(fields, ","))
 	}
 
-	err = forceApi.Get(uri, params, out.(interface{}))
+	_, err = forceApi.Get(uri, params, out.(interface{}))
 
 	return
 }
@@ -108,11 +108,11 @@ func (forceApi *ForceApi) DeleteSObject(id string, in SObject) (err error) {
 	return
 }
 
-func (forceApi *ForceApi) GetSObjectByExternalId(id string, fields []string, out SObject) (err error) {
+func (forceApi *ForceApi) GetSObjectByExternalId(id string, fields []string, out SObject) (statusCode int, err error) {
 	return forceApi.GetSObjectBySpecificExternalType(id, fields, out.ExternalIdAPIName(), out)
 }
 
-func (forceApi *ForceApi) GetSObjectBySpecificExternalType(id string, fields []string, specificExternalId string, out SObject) (err error) {
+func (forceApi *ForceApi) GetSObjectBySpecificExternalType(id string, fields []string, specificExternalId string, out SObject) (statusCode int, err error) {
 	uri := fmt.Sprintf("%v/%v/%v", forceApi.apiSObjects[out.APIName()].URLs[sObjectKey],
 		specificExternalId, id)
 
@@ -121,9 +121,7 @@ func (forceApi *ForceApi) GetSObjectBySpecificExternalType(id string, fields []s
 		params.Add("fields", strings.Join(fields, ","))
 	}
 
-	err = forceApi.Get(uri, params, out.(interface{}))
-
-	return
+	return forceApi.Get(uri, params, out.(interface{}))
 }
 
 func (forceApi *ForceApi) UpsertSObjectByExternalId(id string, in SObject) (responseCode int, resp *SObjectResponse, err error) {


### PR DESCRIPTION
…ernalType

this is to enable searching external type and return better error.
e.g., if it returns 404 when searching opportunity by Opendoor Lead ID, it might be a legitimate case . If it returns any other status code >= 400, the error could indicate something less benign. 
You should be able to detect 404 case by parsing the error and looking for NOT_FOUND, but this is much more arduous and requires domain specific knowledge of the salesforce response.