### PR TITLE
CRP-162 Add smarter salesforce json parser

### DIFF
--- a/force/client.go
+++ b/force/client.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/url"
 
+	"github.com/opendoor-labs/go-force/force/parser"
 	"github.com/opendoor-labs/go-force/forcejson"
 )
 
@@ -111,7 +112,7 @@ func (forceApi *ForceApi) request(method, path string, params url.Values, payloa
 	// Attempt to parse response into out
 	var objectUnmarshalErr error
 	if out != nil {
-		objectUnmarshalErr = forcejson.Unmarshal(respBytes, out)
+		objectUnmarshalErr = parser.ParseSFJSON(respBytes, out)
 		if objectUnmarshalErr == nil {
 			return statusCode, nil
 		}

--- a/force/parser/parser.go
+++ b/force/parser/parser.go
@@ -1,0 +1,52 @@
+package parser
+
+import (
+	"reflect"
+
+	"github.com/opendoor-labs/go-force/forcejson"
+	"github.com/pkg/errors"
+)
+
+func IsSlicePtr(i interface{}) (isptr bool) {
+	defer func() {
+		recover()
+	}()
+
+	slice := reflect.ValueOf(i).Elem()
+
+	// panic if slice doesn't behave like a slice
+	slice.Slice(0, 0)
+
+	return true
+}
+
+func ParseSFJSON(msg []byte, out interface{}) error {
+	err := forcejson.Unmarshal(msg, out)
+
+	if err == nil {
+		return nil
+	}
+
+	if !IsSlicePtr(out) {
+		return err
+	}
+
+	// pointer to the slice
+	slice := reflect.ValueOf(out).Elem()
+
+	slice.Set(reflect.MakeSlice(slice.Type(), 0, 1))
+
+	t := slice.Type().Elem()
+	i := reflect.New(t).Interface()
+
+	err = forcejson.Unmarshal(msg, &i)
+
+	v := reflect.ValueOf(i)
+
+	if err != nil {
+		return errors.Wrap(err, "Unmarshal single object failed")
+	}
+
+	slice.Set(reflect.Append(slice, v.Elem()))
+	return nil
+}

--- a/force/parser/parser.go
+++ b/force/parser/parser.go
@@ -27,6 +27,12 @@ func IsSlicePtr(i interface{}) (isptr bool) {
 // (e.g. [{}, {}, ...]) when multiple objects match the query.  Instead
 // of requiring client code to know that SFDC returns different types
 // based on number of results, allow clients to always pass in a slice.
+//
+// Summary of parsing results given out object types:
+//   single json object, out *slice -> *[T1]
+//   json array of objects, out *slice -> *[T1, T2, ...]
+//   single json object, out struct -> T
+//   json array of objects, out slice -> error
 func ParseSFJSON(msg []byte, out interface{}) error {
 	err := forcejson.Unmarshal(msg, out)
 
@@ -35,7 +41,7 @@ func ParseSFJSON(msg []byte, out interface{}) error {
 	}
 
 	if !IsSlicePtr(out) {
-		return err
+		return errors.Wrap(err, "'out' is not a pointer to a slice")
 	}
 
 	// pointer to the slice

--- a/force/parser/parser.go
+++ b/force/parser/parser.go
@@ -20,6 +20,13 @@ func IsSlicePtr(i interface{}) (isptr bool) {
 	return true
 }
 
+// ParseSFJSON allows a slice of the expected json type to be passed
+// in that will be populated with a object(s) parsed out of msg.  The
+// motivation for this is that SFDC returns a single object (e.g. {})
+// when only one object matches the query, but an array of objects
+// (e.g. [{}, {}, ...]) when multiple objects match the query.  Instead
+// of requiring client code to know that SFDC returns different types
+// based on number of results, allow clients to always pass in a slice.
 func ParseSFJSON(msg []byte, out interface{}) error {
 	err := forcejson.Unmarshal(msg, out)
 

--- a/force/parser/parser_suite_test.go
+++ b/force/parser/parser_suite_test.go
@@ -1,0 +1,13 @@
+package parser_test
+
+import (
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"testing"
+)
+
+func TestParser(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Parser Suite")
+}

--- a/force/parser/parser_test.go
+++ b/force/parser/parser_test.go
@@ -1,0 +1,101 @@
+package parser_test
+
+import (
+	"fmt"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/opendoor-labs/go-force/force/parser"
+)
+
+type Key struct {
+	ID  *int    `json:"id"`
+	Key *string `json:"key"`
+}
+
+var _ = Describe("Parser", func() {
+	var (
+		jsonArray = []byte(`[
+      {"id": 1, "key": "secret-1"},
+      {"id": 2, "key": "secret-2"},
+      {"id": 3, "key": "secret-3"}
+    ]`)
+
+		jsonObj     = []byte(`{"id": 1, "key": "secret-1"}`)
+		jsonInvalid = []byte(`☣`)
+
+		slice []Key
+		key   Key
+	)
+
+	BeforeEach(func() {
+		slice = []Key{}
+	})
+
+	Describe("IsSlicePtr", func() {
+		It("should be true for a slice", func() {
+			Expect(parser.IsSlicePtr(&slice)).To(BeTrue())
+		})
+
+		It("should be false otherwise", func() {
+			Expect(parser.IsSlicePtr(slice)).To(BeFalse())
+			Expect(parser.IsSlicePtr("")).To(BeFalse())
+			Expect(parser.IsSlicePtr(234)).To(BeFalse())
+			Expect(parser.IsSlicePtr(nil)).To(BeFalse())
+		})
+	})
+
+	Describe("ParseSFJSON", func() {
+		Context("with a pointer to a slice", func() {
+			It("should parse single object into the slice of length 1", func() {
+				slice := make([]Key, 0)
+				err := parser.ParseSFJSON(jsonObj, &slice)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(slice)).To(Equal(1))
+
+				obj := slice[0]
+				Expect(*obj.ID).To(Equal(1))
+				Expect(*obj.Key).To(Equal("secret-1"))
+			})
+
+			It("should parse an array into the slice", func() {
+				err := parser.ParseSFJSON(jsonArray, &slice)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(len(slice)).To(Equal(3))
+
+				for i := 0; i < 3; i++ {
+					obj := slice[i]
+					Expect(*obj.ID).To(Equal(i + 1))
+					Expect(*obj.Key).To(Equal(fmt.Sprintf("secret-%d", i+1)))
+				}
+			})
+
+			It("should return an error if invalid JSON", func() {
+				err := parser.ParseSFJSON(jsonInvalid, &slice)
+				Expect(err).To(HaveOccurred())
+				Expect(len(slice)).To(Equal(0))
+			})
+		})
+
+		Context("with a pointer to a struct", func() {
+			It("should parse an object", func() {
+				err := parser.ParseSFJSON(jsonObj, &key)
+				Expect(err).ToNot(HaveOccurred())
+				Expect(*key.ID).To(Equal(1))
+				Expect(*key.Key).To(Equal("secret-1"))
+			})
+
+			It("should return an error if json is an array", func() {
+				err := parser.ParseSFJSON(jsonArray, &key)
+				Expect(err).To(HaveOccurred())
+			})
+
+			It("should return an error if invalid JSON", func() {
+				err := parser.ParseSFJSON(jsonInvalid, &key)
+				Expect(err).To(HaveOccurred())
+				Expect(len(slice)).To(Equal(0))
+			})
+		})
+	})
+})


### PR DESCRIPTION
This change adapts the parsing logic to unmarshal into a slice if a json array
was received.  If a non-slice was provided to unmarshal, the original behavior
is maintained.