### PR TITLE
CRP-201 Change the *ByExternalId methods to require the externalKey

### DIFF
--- a/force/api.go
+++ b/force/api.go
@@ -183,10 +183,9 @@ type RestAPI interface {
 	InsertSObject(in SObject) (resp *SObjectResponse, err error)
 	UpdateSObject(id string, in SObject) (err error)
 	DeleteSObject(id string, in SObject) (err error)
-	GetSObjectByExternalId(id string, fields []string, out SObject) (statusCode int, err error)
-	GetSObjectBySpecificExternalType(id string, fields []string, specificExternalType string, out SObject) (statusCode int, err error)
-	UpsertSObjectByExternalId(id string, in SObject) (statusCode int, resp *SObjectResponse, err error)
-	DeleteSObjectByExternalId(id string, in SObject) (err error)
+	GetSObjectByExternalId(externalKey, externalId string, fields []string, out SObject) (statusCode int, err error)
+	UpsertSObjectByExternalId(externalKey string, externalId string, in SObject) (responseCode int, resp *SObjectResponse, err error)
+	DeleteSObjectByExternalId(externalKey, externalId string, in SObject) (err error)
 	GetInstanceURL() string
 	GetAccessToken() string
 	RefreshToken() error

--- a/sobjects/base.go
+++ b/sobjects/base.go
@@ -38,12 +38,6 @@ type SObjectAttributes struct {
 	Url  string `force:"url,omitempty"`
 }
 
-// Implementing this here because most objects don't have an external id and as such this is not needed.
-// Feel free to override this function when embedding the BaseSObject in other structs.
-func (b BaseSObject) ExternalIdAPIName() string {
-	return ""
-}
-
 // Fields that are returned in every query response. Use this to build custom structs.
 // type MyCustomQueryResponse struct {
 // 	BaseQuery


### PR DESCRIPTION
Remove the ExternalAPIName() from the SObject interface as it doesn't
make sense for SObjects with multiple external IDs, e.g. a Lead may
have an external Lead_ID__c and an external Contact_ID__c.

Since this is an API change, we will need to do a coordinated deploy of SFSync. This should be merged directly preceding the merge of the SFSync PR with the update to use the new API.