### PR TITLE
Convert to ginkgo test

### DIFF
--- a/force/api_test.go
+++ b/force/api_test.go
@@ -1,39 +1,41 @@
 package force
 
 import (
+	. "github.com/onsi/ginkgo"
 	"net/http"
-	"testing"
 )
 
-func TestHasAccess(t *testing.T) {
+var _ = Describe("Testing with Ginkgo", func() {
+	It("has access", func() {
 
-	oauth := &forceOauth{
-		clientId:      testClientId,
-		clientSecret:  testClientSecret,
-		userName:      testUserName,
-		password:      testPassword,
-		securityToken: testSecurityToken,
-		environment:   testEnvironment,
-	}
+		oauth := &forceOauth{
+			clientId:      testClientId,
+			clientSecret:  testClientSecret,
+			userName:      testUserName,
+			password:      testPassword,
+			securityToken: testSecurityToken,
+			environment:   testEnvironment,
+		}
 
-	forceApi := &ForceApi{
-		apiResources:           make(map[string]string),
-		apiSObjects:            make(map[string]*SObjectMetaData),
-		apiSObjectDescriptions: make(map[string]*SObjectDescription),
-		apiVersion:             version,
-		oauth:                  oauth,
-		httpClient:             http.DefaultClient,
-	}
+		forceApi := &ForceApi{
+			apiResources:           make(map[string]string),
+			apiSObjects:            make(map[string]*SObjectMetaData),
+			apiSObjectDescriptions: make(map[string]*SObjectDescription),
+			apiVersion:             version,
+			oauth:                  oauth,
+			httpClient:             http.DefaultClient,
+		}
 
-	apiName := "AbadCompliance___c"
+		apiName := "AbadCompliance___c"
 
-	forceApi.apiSObjects[apiName] = &SObjectMetaData{}
-	validObjects := []string{apiName}
-	if value := forceApi.HasAccess(validObjects); !value {
-		t.Error("expected to return true, but got false")
-	}
-	invalidObjects := []string{"Alien"}
-	if value := forceApi.HasAccess(invalidObjects); value {
-		t.Error("expected to return false, but got true")
-	}
-}
+		forceApi.apiSObjects[apiName] = &SObjectMetaData{}
+		validObjects := []string{apiName}
+		if value := forceApi.HasAccess(validObjects); !value {
+			GinkgoT().Error("expected to return true, but got false")
+		}
+		invalidObjects := []string{"Alien"}
+		if value := forceApi.HasAccess(invalidObjects); value {
+			GinkgoT().Error("expected to return false, but got true")
+		}
+	})
+})

--- a/force/error_test.go
+++ b/force/error_test.go
@@ -2,33 +2,36 @@ package force
 
 import (
 	"fmt"
-	"testing"
+	. "github.com/onsi/ginkgo"
 )
 
-func TestWasNotFound(t *testing.T) {
-	apiErr := ApiErrors{
-		&ApiError{ErrorCode: "NOT_FOUND"},
-	}
+var _ = Describe("Testing with Ginkgo", func() {
+	It("was not found", func() {
 
-	found, err := WasNotFound(apiErr)
-	if err != nil {
-		fmt.Println(err)
-		t.Error("expected WasNotFound not to return an error")
-	}
-	if !found {
-		t.Error("expected err to say it was not found")
-	}
+		apiErr := ApiErrors{
+			&ApiError{ErrorCode: "NOT_FOUND"},
+		}
 
-	apiErr = ApiErrors{
-		&ApiError{ErrorCode: "SO_TOTALLY_FOUND"},
-	}
+		found, err := WasNotFound(apiErr)
+		if err != nil {
+			fmt.Println(err)
+			GinkgoT().Error("expected WasNotFound not to return an error")
+		}
+		if !found {
+			GinkgoT().Error("expected err to say it was not found")
+		}
 
-	found, err = WasNotFound(apiErr)
-	if err != nil {
-		fmt.Println(err)
-		t.Error("expected WasNotFound not to return an error")
-	}
-	if found {
-		t.Error("expected err not to say it was not found")
-	}
-}
+		apiErr = ApiErrors{
+			&ApiError{ErrorCode: "SO_TOTALLY_FOUND"},
+		}
+
+		found, err = WasNotFound(apiErr)
+		if err != nil {
+			fmt.Println(err)
+			GinkgoT().Error("expected WasNotFound not to return an error")
+		}
+		if found {
+			GinkgoT().Error("expected err not to say it was not found")
+		}
+	})
+})

--- a/force/force_suite_test.go
+++ b/force/force_suite_test.go
@@ -1,4 +1,4 @@
-package parser_test
+package force_test
 
 import (
 	"testing"
@@ -9,5 +9,5 @@ import (
 
 func TestForce(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(GinkgoT(), "Parser Suite")
+	RunSpecs(t, "Force Suite")
 }

--- a/force/force_test.go
+++ b/force/force_test.go
@@ -2,56 +2,94 @@ package force
 
 import (
 	"net/http"
-	"testing"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/opendoor-labs/go-force/sobjects"
 )
 
-func TestCreateWithAccessToken(t *testing.T) {
+var _ = Describe("Testing with Ginkgo", func() {
+	It("create with access token", func() {
 
-	// Manually grab an OAuth token, so that we can pass it into CreateWithAccessToken
-	oauth := &forceOauth{
-		clientId:      testClientId,
-		clientSecret:  testClientSecret,
-		userName:      testUserName,
-		password:      testPassword,
-		securityToken: testSecurityToken,
-		environment:   testEnvironment,
-		httpClient:    http.DefaultClient,
-	}
+		oauth := &forceOauth{
+			clientId:      testClientId,
+			clientSecret:  testClientSecret,
+			userName:      testUserName,
+			password:      testPassword,
+			securityToken: testSecurityToken,
+			environment:   testEnvironment,
+			httpClient:    http.DefaultClient,
+		}
 
-	forceApi := &ForceApi{
-		apiResources:           make(map[string]string),
-		apiSObjects:            make(map[string]*SObjectMetaData),
-		apiSObjectDescriptions: make(map[string]*SObjectDescription),
-		apiVersion:             version,
-		oauth:                  oauth,
-		httpClient:             http.DefaultClient,
-	}
+		forceApi := &ForceApi{
+			apiResources:           make(map[string]string),
+			apiSObjects:            make(map[string]*SObjectMetaData),
+			apiSObjectDescriptions: make(map[string]*SObjectDescription),
+			apiVersion:             version,
+			oauth:                  oauth,
+			httpClient:             http.DefaultClient,
+		}
 
-	err := forceApi.oauth.Authenticate()
-	if err != nil {
-		t.Fatalf("Unable to authenticate: %#v", err)
-	}
-	if err := forceApi.oauth.Validate(); err != nil {
-		t.Fatalf("Oauth object is invlaid: %#v", err)
-	}
+		err := forceApi.oauth.Authenticate()
+		if err != nil {
+			GinkgoT().Fatalf("Unable to authenticate: %#v", err)
+		}
+		if err := forceApi.oauth.Validate(); err != nil {
+			GinkgoT().Fatalf("Oauth object is invlaid: %#v", err)
+		}
 
-	// We shouldn't hit any errors creating a new force instance and manually passing in these oauth details now.
-	newForceApi, err := CreateWithAccessToken(testVersion, testClientId, forceApi.oauth.AccessToken, forceApi.oauth.InstanceUrl, http.DefaultClient)
-	if err != nil {
-		t.Fatalf("Unable to create new force api instance using pre-defined oauth details: %#v", err)
-	}
-	if err := newForceApi.oauth.Validate(); err != nil {
-		t.Fatalf("Oauth object is invlaid: %#v", err)
-	}
+		newForceApi, err := CreateWithAccessToken(testVersion, testClientId, forceApi.oauth.AccessToken, forceApi.oauth.InstanceUrl, http.DefaultClient)
+		if err != nil {
+			GinkgoT().Fatalf("Unable to create new force api instance using pre-defined oauth details: %#v", err)
+		}
+		if err := newForceApi.oauth.Validate(); err != nil {
+			GinkgoT().Fatalf("Oauth object is invlaid: %#v", err)
+		}
 
-	// We should be able to make a basic query now with the newly created object (i.e. the oauth details should be correctly usable).
-	_, err = newForceApi.DescribeSObject(&sobjects.Account{})
-	if err != nil {
-		t.Fatalf("Failed to retrieve description of sobject: %v", err)
-	}
-}
+		_, err = newForceApi.DescribeSObject(&sobjects.Account{})
+		if err != nil {
+			GinkgoT().Fatalf("Failed to retrieve description of sobject: %v", err)
+		}
+	})
+	It("passed http client is used", func() {
+
+		oauth := &forceOauth{
+			clientId:      testClientId,
+			clientSecret:  testClientSecret,
+			userName:      testUserName,
+			password:      testPassword,
+			securityToken: testSecurityToken,
+			environment:   testEnvironment,
+			httpClient:    http.DefaultClient,
+		}
+
+		forceApi := &ForceApi{
+			apiResources:           make(map[string]string),
+			apiSObjects:            make(map[string]*SObjectMetaData),
+			apiSObjectDescriptions: make(map[string]*SObjectDescription),
+			apiVersion:             version,
+			oauth:                  oauth,
+			httpClient:             http.DefaultClient,
+		}
+
+		err := forceApi.oauth.Authenticate()
+		if err != nil {
+			GinkgoT().Fatalf("Unable to authenticate: %#v", err)
+		}
+		if err := forceApi.oauth.Validate(); err != nil {
+			GinkgoT().Fatalf("Oauth object is invlaid: %#v", err)
+		}
+
+		trt := TestRoundTripper{CallCount: 0, proxied: http.DefaultTransport}
+		httpClient := &http.Client{Transport: &trt}
+		newForceApi, _ := CreateWithAccessToken(testVersion, testClientId, forceApi.oauth.AccessToken, forceApi.oauth.InstanceUrl, httpClient)
+
+		newForceApi.DescribeSObject(&sobjects.Account{})
+
+		if trt.CallCount < 1 {
+			GinkgoT().Fatalf("Passed in http client was not called")
+		}
+	})
+})
 
 type TestRoundTripper struct {
 	CallCount int
@@ -61,45 +99,4 @@ type TestRoundTripper struct {
 func (trt *TestRoundTripper) RoundTrip(req *http.Request) (res *http.Response, e error) {
 	trt.CallCount++
 	return trt.proxied.RoundTrip(req)
-}
-
-func TestPassedHttpClientIsUsed(t *testing.T) {
-	// Manually grab an OAuth token, so that we can pass it into CreateWithAccessToken
-	oauth := &forceOauth{
-		clientId:      testClientId,
-		clientSecret:  testClientSecret,
-		userName:      testUserName,
-		password:      testPassword,
-		securityToken: testSecurityToken,
-		environment:   testEnvironment,
-		httpClient:    http.DefaultClient,
-	}
-
-	forceApi := &ForceApi{
-		apiResources:           make(map[string]string),
-		apiSObjects:            make(map[string]*SObjectMetaData),
-		apiSObjectDescriptions: make(map[string]*SObjectDescription),
-		apiVersion:             version,
-		oauth:                  oauth,
-		httpClient:             http.DefaultClient,
-	}
-
-	err := forceApi.oauth.Authenticate()
-	if err != nil {
-		t.Fatalf("Unable to authenticate: %#v", err)
-	}
-	if err := forceApi.oauth.Validate(); err != nil {
-		t.Fatalf("Oauth object is invlaid: %#v", err)
-	}
-
-	// need to proxy the real client b/c that's how goforce tests roll
-	trt := TestRoundTripper{CallCount: 0, proxied: http.DefaultTransport}
-	httpClient := &http.Client{Transport: &trt}
-	newForceApi, _ := CreateWithAccessToken(testVersion, testClientId, forceApi.oauth.AccessToken, forceApi.oauth.InstanceUrl, httpClient)
-
-	newForceApi.DescribeSObject(&sobjects.Account{})
-
-	if trt.CallCount < 1 {
-		t.Fatalf("Passed in http client was not called")
-	}
 }

--- a/force/forcefakes/forcefakes_suite_test.go
+++ b/force/forcefakes/forcefakes_suite_test.go
@@ -1,4 +1,4 @@
-package parser_test
+package forcefakes_test
 
 import (
 	"testing"
@@ -7,7 +7,7 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-func TestForce(t *testing.T) {
+func TestForcefakes(t *testing.T) {
 	RegisterFailHandler(Fail)
-	RunSpecs(GinkgoT(), "Parser Suite")
+	RunSpecs(t, "Forcefakes Suite")
 }

--- a/force/limits_test.go
+++ b/force/limits_test.go
@@ -1,17 +1,17 @@
 package force
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo"
 )
 
-func TestLimits(t *testing.T) {
-	forceApi := createTest()
-	limits, err := forceApi.GetLimits()
-	if err != nil {
-		// Developer Accounts, which the testbed uses, do not have access to the limits API. So this will always fail.
-		// t.Fatalf("Failed to get Limits: %v", err)
-		t.Logf("Failed to get Limits, this is expected due to the developer account: %v", err)
-	}
+var _ = Describe("Testing with Ginkgo", func() {
+	It("limits", func() {
 
-	t.Log(limits)
-}
+		forceApi := createTest()
+		limits, err := forceApi.GetLimits()
+		if err != nil {
+			GinkgoT().Logf("Failed to get Limits, this is expected due to the developer account: %v", err)
+		}
+		GinkgoT().Log(limits)
+	})
+})

--- a/force/oauth_test.go
+++ b/force/oauth_test.go
@@ -1,13 +1,16 @@
 package force
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo"
 )
 
-func TestOauth(t *testing.T) {
-	forceApi := createTest()
-	// Verify oauth object is valid
-	if err := forceApi.oauth.Validate(); err != nil {
-		t.Fatalf("Oauth object is invlaid: %#v", err)
-	}
-}
+var _ = Describe("Testing with Ginkgo", func() {
+	It("oauth", func() {
+
+		forceApi := createTest()
+
+		if err := forceApi.oauth.Validate(); err != nil {
+			GinkgoT().Fatalf("Oauth object is invlaid: %#v", err)
+		}
+	})
+})

--- a/force/query_test.go
+++ b/force/query_test.go
@@ -2,10 +2,53 @@ package force
 
 import (
 	"fmt"
-	"testing"
 
+	. "github.com/onsi/ginkgo"
 	"github.com/opendoor-labs/go-force/sobjects"
 )
+
+var _ = Describe("Testing with Ginkgo", func() {
+	It("query", func() {
+
+		forceApi := createTest()
+		desc, err := forceApi.DescribeSObject(&sobjects.Account{})
+		if err != nil {
+			GinkgoT().Fatalf("Failed to retrieve description of sobject: %v", err)
+		}
+
+		list := &AccountQueryResponse{}
+		err = forceApi.Query(BuildQuery(desc.AllFields, desc.Name, nil), list)
+		if err != nil {
+			GinkgoT().Fatalf("Failed to query: %v", err)
+		}
+		GinkgoT().Logf("%#v", list)
+	})
+	It("query all", func() {
+
+		forceApi := createTest()
+
+		newId := insertSObject(forceApi, GinkgoT())
+		deleteSObject(forceApi, GinkgoT(), newId)
+
+		desc, err := forceApi.DescribeSObject(&sobjects.Account{})
+		if err != nil {
+			GinkgoT().Fatalf("Failed to retrieve description of sobject: %v", err)
+		}
+
+		list := &AccountQueryResponse{}
+		err = forceApi.QueryAll(fmt.Sprintf(queryAll, desc.AllFields, newId), list)
+		if err != nil {
+			GinkgoT().Fatalf("Failed to queryAll: %v", err)
+		}
+
+		if len(list.Records) == 0 {
+			GinkgoT().Fatal("Failed to retrieve deleted record using queryAll")
+		}
+		GinkgoT().Logf("%#v", list)
+	})
+	It("query next", func() {
+	})
+})
 
 const (
 	queryAll = "SELECT %v FROM Account WHERE Id = '%v'"
@@ -14,49 +57,4 @@ const (
 type AccountQueryResponse struct {
 	sobjects.BaseQuery
 	Records []sobjects.Account `json:"Records" force:"records"`
-}
-
-func TestQuery(t *testing.T) {
-	forceApi := createTest()
-	desc, err := forceApi.DescribeSObject(&sobjects.Account{})
-	if err != nil {
-		t.Fatalf("Failed to retrieve description of sobject: %v", err)
-	}
-
-	list := &AccountQueryResponse{}
-	err = forceApi.Query(BuildQuery(desc.AllFields, desc.Name, nil), list)
-	if err != nil {
-		t.Fatalf("Failed to query: %v", err)
-	}
-
-	t.Logf("%#v", list)
-}
-
-func TestQueryAll(t *testing.T) {
-	forceApi := createTest()
-	// First Insert and Delete an Account
-	newId := insertSObject(forceApi, t)
-	deleteSObject(forceApi, t, newId)
-
-	// Then look for it.
-	desc, err := forceApi.DescribeSObject(&sobjects.Account{})
-	if err != nil {
-		t.Fatalf("Failed to retrieve description of sobject: %v", err)
-	}
-
-	list := &AccountQueryResponse{}
-	err = forceApi.QueryAll(fmt.Sprintf(queryAll, desc.AllFields, newId), list)
-	if err != nil {
-		t.Fatalf("Failed to queryAll: %v", err)
-	}
-
-	if len(list.Records) == 0 {
-		t.Fatal("Failed to retrieve deleted record using queryAll")
-	}
-
-	t.Logf("%#v", list)
-}
-
-func TestQueryNext(t *testing.T) {
-	// TODO
 }

--- a/forcejson/bench_test.go
+++ b/forcejson/bench_test.go
@@ -1,13 +1,3 @@
-// Copyright 2011 The Go Authors.  All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
-// Large data benchmark.
-// The JSON data is a summary of agl's changes in the
-// go, webkit, and chromium open source projects.
-// We benchmark converting between the JSON form
-// and in-memory data structures.
-
 package forcejson
 
 import (
@@ -16,7 +6,12 @@ import (
 	"io/ioutil"
 	"os"
 	"testing"
+
+	. "github.com/onsi/ginkgo"
 )
+
+var _ = Describe("Testing with Ginkgo", func() {
+})
 
 type codeResponse struct {
 	Tree     *codeNode `force:"tree"`
@@ -115,7 +110,7 @@ func BenchmarkCodeDecoder(b *testing.B) {
 	var r codeResponse
 	for i := 0; i < b.N; i++ {
 		buf.Write(codeJSON)
-		// hide EOF
+
 		buf.WriteByte('\n')
 		buf.WriteByte('\n')
 		buf.WriteByte('\n')

--- a/forcejson/decode_test.go
+++ b/forcejson/decode_test.go
@@ -1,7 +1,3 @@
-// Copyright 2010 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package forcejson
 
 import (
@@ -11,9 +7,466 @@ import (
 	"image"
 	"reflect"
 	"strings"
-	"testing"
+
+	. "github.com/onsi/ginkgo"
 	"time"
 )
+
+var _ = Describe("Testing with Ginkgo", func() {
+	It("marshal", func() {
+
+		b, err := Marshal(allValue)
+		if err != nil {
+			GinkgoT().Fatalf("Marshal allValue: %v", err)
+		}
+		if string(b) != allValueCompact {
+			GinkgoT().Errorf("Marshal allValueCompact")
+			diff(GinkgoT(), b, []byte(allValueCompact))
+			return
+		}
+
+		b, err = Marshal(pallValue)
+		if err != nil {
+			GinkgoT().Fatalf("Marshal pallValue: %v", err)
+		}
+		if string(b) != pallValueCompact {
+			GinkgoT().Errorf("Marshal pallValueCompact")
+			diff(GinkgoT(), b, []byte(pallValueCompact))
+			return
+		}
+	})
+	It("marshal bad u t f8", func() {
+
+		for _, tt := range badUTF8 {
+			b, err := Marshal(tt.in)
+			if string(b) != tt.out || err != nil {
+				GinkgoT().Errorf("Marshal(%q) = %#q, %v, want %#q, nil", tt.in, b, err, tt.out)
+			}
+		}
+	})
+	It("marshal number zero val", func() {
+
+		var n Number
+		out, err := Marshal(n)
+		if err != nil {
+			GinkgoT().Fatal(err)
+		}
+		outStr := string(out)
+		if outStr != "0" {
+			GinkgoT().Fatalf("Invalid zero val for Number: %q", outStr)
+		}
+	})
+	It("marshal embeds", func() {
+
+		top := &Top{
+			Level0: 1,
+			Embed0: Embed0{
+				Level1b: 2,
+				Level1c: 3,
+			},
+			Embed0a: &Embed0a{
+				Level1a: 5,
+				Level1b: 6,
+			},
+			Embed0b: &Embed0b{
+				Level1a: 8,
+				Level1b: 9,
+				Level1c: 10,
+				Level1d: 11,
+				Level1e: 12,
+			},
+			Loop: Loop{
+				Loop1: 13,
+				Loop2: 14,
+			},
+			Embed0p: Embed0p{
+				Point: image.Point{X: 15, Y: 16},
+			},
+			Embed0q: Embed0q{
+				Point: Point{Z: 17},
+			},
+			embed: embed{
+				Q: 18,
+			},
+		}
+		b, err := Marshal(top)
+		if err != nil {
+			GinkgoT().Fatal(err)
+		}
+		want := "{\"Level0\":1,\"Level1b\":2,\"Level1c\":3,\"Level1a\":5,\"LEVEL1B\":6,\"e\":{\"Level1a\":8,\"Level1b\":9,\"Level1c\":10,\"Level1d\":11,\"x\":12},\"Loop1\":13,\"Loop2\":14,\"X\":15,\"Y\":16,\"Z\":17,\"Q\":18}"
+		if string(b) != want {
+			GinkgoT().Errorf("Wrong marshal result.\n got: %q\nwant: %q", b, want)
+		}
+	})
+	It("unmarshal", func() {
+
+		for i, tt := range unmarshalTests {
+			var scan scanner
+			in := []byte(tt.in)
+			if err := checkValid(in, &scan); err != nil {
+				if !reflect.DeepEqual(err, tt.err) {
+					GinkgoT().Errorf("#%d: checkValid: %#v", i, err)
+					continue
+				}
+			}
+			if tt.ptr == nil {
+				continue
+			}
+
+			v := reflect.New(reflect.TypeOf(tt.ptr).Elem())
+			dec := NewDecoder(bytes.NewReader(in))
+			if tt.useNumber {
+				dec.UseNumber()
+			}
+			if err := dec.Decode(v.Interface()); !reflect.DeepEqual(err, tt.err) {
+				GinkgoT().Errorf("#%d: %v want %v", i, err, tt.err)
+				continue
+			}
+			if !reflect.DeepEqual(v.Elem().Interface(), tt.out) {
+				GinkgoT().Errorf("#%d: mismatch\nhave: %#+v\nwant: %#+v", i, v.Elem().Interface(), tt.out)
+				data, _ := Marshal(v.Elem().Interface())
+				println(string(data))
+				data, _ = Marshal(tt.out)
+				println(string(data))
+				continue
+			}
+
+			if tt.err == nil {
+				enc, err := Marshal(v.Interface())
+				if err != nil {
+					GinkgoT().Errorf("#%d: error re-marshaling: %v", i, err)
+					continue
+				}
+				vv := reflect.New(reflect.TypeOf(tt.ptr).Elem())
+				dec = NewDecoder(bytes.NewReader(enc))
+				if tt.useNumber {
+					dec.UseNumber()
+				}
+				if err := dec.Decode(vv.Interface()); err != nil {
+					GinkgoT().Errorf("#%d: error re-unmarshaling %#q: %v", i, enc, err)
+					continue
+				}
+				if !reflect.DeepEqual(v.Elem().Interface(), vv.Elem().Interface()) {
+					GinkgoT().Errorf("#%d: mismatch\nhave: %#+v\nwant: %#+v", i, v.Elem().Interface(), vv.Elem().Interface())
+					GinkgoT().Errorf("     In: %q", strings.Map(noSpace, string(in)))
+					GinkgoT().Errorf("Marshal: %q", strings.Map(noSpace, string(enc)))
+					continue
+				}
+			}
+		}
+	})
+	It("unmarshal marshal", func() {
+
+		initBig()
+		var v interface{}
+		if err := Unmarshal(jsonBig, &v); err != nil {
+			GinkgoT().Fatalf("Unmarshal: %v", err)
+		}
+		b, err := Marshal(v)
+		if err != nil {
+			GinkgoT().Fatalf("Marshal: %v", err)
+		}
+		if !bytes.Equal(jsonBig, b) {
+			GinkgoT().Errorf("Marshal jsonBig")
+			diff(GinkgoT(), b, jsonBig)
+			return
+		}
+	})
+	It("number accessors", func() {
+
+		for _, tt := range numberTests {
+			n := Number(tt.in)
+			if s := n.String(); s != tt.in {
+				GinkgoT().Errorf("Number(%q).String() is %q", tt.in, s)
+			}
+			if i, err := n.Int64(); err == nil && tt.intErr == "" && i != tt.i {
+				GinkgoT().Errorf("Number(%q).Int64() is %d", tt.in, i)
+			} else if (err == nil && tt.intErr != "") || (err != nil && err.Error() != tt.intErr) {
+				GinkgoT().Errorf("Number(%q).Int64() wanted error %q but got: %v", tt.in, tt.intErr, err)
+			}
+			if f, err := n.Float64(); err == nil && tt.floatErr == "" && f != tt.f {
+				GinkgoT().Errorf("Number(%q).Float64() is %g", tt.in, f)
+			} else if (err == nil && tt.floatErr != "") || (err != nil && err.Error() != tt.floatErr) {
+				GinkgoT().Errorf("Number(%q).Float64() wanted error %q but got: %v", tt.in, tt.floatErr, err)
+			}
+		}
+	})
+	It("large byte slice", func() {
+
+		s0 := make([]byte, 2000)
+		for i := range s0 {
+			s0[i] = byte(i)
+		}
+		b, err := Marshal(s0)
+		if err != nil {
+			GinkgoT().Fatalf("Marshal: %v", err)
+		}
+		var s1 []byte
+		if err := Unmarshal(b, &s1); err != nil {
+			GinkgoT().Fatalf("Unmarshal: %v", err)
+		}
+		if !bytes.Equal(s0, s1) {
+			GinkgoT().Errorf("Marshal large byte slice")
+			diff(GinkgoT(), s0, s1)
+		}
+	})
+	It("unmarshal interface", func() {
+
+		var xint Xint
+		var i interface{} = &xint
+		if err := Unmarshal([]byte(`{"X":1}`), &i); err != nil {
+			GinkgoT().Fatalf("Unmarshal: %v", err)
+		}
+		if xint.X != 1 {
+			GinkgoT().Fatalf("Did not write to xint")
+		}
+	})
+	It("unmarshal ptr ptr", func() {
+
+		var xint Xint
+		pxint := &xint
+		if err := Unmarshal([]byte(`{"X":1}`), &pxint); err != nil {
+			GinkgoT().Fatalf("Unmarshal: %v", err)
+		}
+		if xint.X != 1 {
+			GinkgoT().Fatalf("Did not write to xint")
+		}
+	})
+	It("escape", func() {
+
+		const input = `"foobar"<html>` + " [\u2028 \u2029]"
+		const expected = `"\"foobar\"\u003chtml\u003e [\u2028 \u2029]"`
+		b, err := Marshal(input)
+		if err != nil {
+			GinkgoT().Fatalf("Marshal error: %v", err)
+		}
+		if s := string(b); s != expected {
+			GinkgoT().Errorf("Encoding of [%s]:\n got [%s]\nwant [%s]", input, s, expected)
+		}
+	})
+	It("error message from misused string", func() {
+
+		for n, tt := range wrongStringTests {
+			r := strings.NewReader(tt.in)
+			var s WrongString
+			err := NewDecoder(r).Decode(&s)
+			got := fmt.Sprintf("%v", err)
+			if got != tt.err {
+				GinkgoT().Errorf("%d. got err = %q, want %q", n, got, tt.err)
+			}
+		}
+	})
+	It("ref unmarshal", func() {
+
+		type S struct {
+			R0 Ref
+			R1 *Ref
+			R2 RefText
+			R3 *RefText
+		}
+		want := S{
+			R0: 12,
+			R1: new(Ref),
+			R2: 13,
+			R3: new(RefText),
+		}
+		*want.R1 = 12
+		*want.R3 = 13
+
+		var got S
+		if err := Unmarshal([]byte(`{"R0":"ref","R1":"ref","R2":"ref","R3":"ref"}`), &got); err != nil {
+			GinkgoT().Fatalf("Unmarshal: %v", err)
+		}
+		if !reflect.DeepEqual(got, want) {
+			GinkgoT().Errorf("got %+v, want %+v", got, want)
+		}
+	})
+	It("empty string", func() {
+
+		type T2 struct {
+			Number1 int `force:",string"`
+			Number2 int `force:",string"`
+		}
+		data := `{"Number1":"1", "Number2":""}`
+		dec := NewDecoder(strings.NewReader(data))
+		var t2 T2
+		err := dec.Decode(&t2)
+		if err == nil {
+			GinkgoT().Fatal("Decode: did not return error")
+		}
+		if t2.Number1 != 1 {
+			GinkgoT().Fatal("Decode: did not set Number1")
+		}
+	})
+	It("interface set", func() {
+
+		for _, tt := range interfaceSetTests {
+			b := struct{ X interface{} }{tt.pre}
+			blob := `{"X":` + tt.json + `}`
+			if err := Unmarshal([]byte(blob), &b); err != nil {
+				GinkgoT().Errorf("Unmarshal %#q: %v", blob, err)
+				continue
+			}
+			if !reflect.DeepEqual(b.X, tt.post) {
+				GinkgoT().Errorf("Unmarshal %#q into %#v: X=%#v, want %#v", blob, tt.pre, b.X, tt.post)
+			}
+		}
+	})
+	It("unmarshal nulls", func() {
+
+		jsonData := []byte(`{
+		"Bool"    : null, 
+		"Int"     : null, 
+		"Int8"    : null,
+		"Int16"   : null,
+		"Int32"   : null,
+		"Int64"   : null,
+		"Uint"    : null,
+		"Uint8"   : null,
+		"Uint16"  : null,
+		"Uint32"  : null,
+		"Uint64"  : null,
+		"Float32" : null,
+		"Float64" : null,
+		"String"  : null}`)
+
+		nulls := All{
+			Bool:    true,
+			Int:     2,
+			Int8:    3,
+			Int16:   4,
+			Int32:   5,
+			Int64:   6,
+			Uint:    7,
+			Uint8:   8,
+			Uint16:  9,
+			Uint32:  10,
+			Uint64:  11,
+			Float32: 12.1,
+			Float64: 13.1,
+			String:  "14"}
+
+		err := Unmarshal(jsonData, &nulls)
+		if err != nil {
+			GinkgoT().Errorf("Unmarshal of null values failed: %v", err)
+		}
+		if !nulls.Bool || nulls.Int != 2 || nulls.Int8 != 3 || nulls.Int16 != 4 || nulls.Int32 != 5 || nulls.Int64 != 6 ||
+			nulls.Uint != 7 || nulls.Uint8 != 8 || nulls.Uint16 != 9 || nulls.Uint32 != 10 || nulls.Uint64 != 11 ||
+			nulls.Float32 != 12.1 || nulls.Float64 != 13.1 || nulls.String != "14" {
+			GinkgoT().Errorf("Unmarshal of null values affected primitives")
+		}
+	})
+	It("string kind", func() {
+
+		type stringKind string
+
+		var m1, m2 map[stringKind]int
+		m1 = map[stringKind]int{
+			"foo": 42,
+		}
+
+		data, err := Marshal(m1)
+		if err != nil {
+			GinkgoT().Errorf("Unexpected error marshalling: %v", err)
+		}
+
+		err = Unmarshal(data, &m2)
+		if err != nil {
+			GinkgoT().Errorf("Unexpected error unmarshalling: %v", err)
+		}
+
+		if !reflect.DeepEqual(m1, m2) {
+			GinkgoT().Error("Items should be equal after encoding and then decoding")
+		}
+	})
+	It("unmarshal type error", func() {
+
+		for _, item := range decodeTypeErrorTests {
+			err := Unmarshal([]byte(item.src), item.dest)
+			if _, ok := err.(*UnmarshalTypeError); !ok {
+				GinkgoT().Errorf("expected type error for Unmarshal(%q, type %T): got %T",
+					item.src, item.dest, err)
+			}
+		}
+	})
+	It("unmarshal syntax", func() {
+
+		var x interface{}
+		for _, src := range unmarshalSyntaxTests {
+			err := Unmarshal([]byte(src), &x)
+			if _, ok := err.(*SyntaxError); !ok {
+				GinkgoT().Errorf("expected syntax error for Unmarshal(%q): got %T", src, err)
+			}
+		}
+	})
+	It("unmarshal unexported", func() {
+
+		input := `{"Name": "Bob", "m": {"x": 123}, "m2": {"y": 456}, "abcd": {"z": 789}}`
+		want := &unexportedFields{Name: "Bob"}
+
+		out := &unexportedFields{}
+		err := Unmarshal([]byte(input), out)
+		if err != nil {
+			GinkgoT().Errorf("got error %v, expected nil", err)
+		}
+		if !reflect.DeepEqual(out, want) {
+			GinkgoT().Errorf("got %q, want %q", out, want)
+		}
+	})
+	It("unmarshal j s o n literal error", func() {
+
+		var t3 Time3339
+		err := Unmarshal([]byte(`"0000-00-00T00:00:00Z"`), &t3)
+		if err == nil {
+			GinkgoT().Fatalf("expected error; got time %v", time.Time(t3))
+		}
+		if !strings.Contains(err.Error(), "range") {
+			GinkgoT().Errorf("got err = %v; want out of range error", err)
+		}
+	})
+	It("skip array objects", func() {
+
+		json := `[{}]`
+		var dest [0]interface{}
+
+		err := Unmarshal([]byte(json), &dest)
+		if err != nil {
+			GinkgoT().Errorf("got error %q, want nil", err)
+		}
+	})
+	It("prefilled", func() {
+
+		ptrToMap := func(m map[string]interface{}) *map[string]interface{} { return &m }
+
+		var prefillTests = []struct {
+			in  string
+			ptr interface{}
+			out interface{}
+		}{
+			{
+				in:  `{"X": 1, "Y": 2}`,
+				ptr: &XYZ{X: float32(3), Y: int16(4), Z: 1.5},
+				out: &XYZ{X: float64(1), Y: float64(2), Z: 1.5},
+			},
+			{
+				in:  `{"X": 1, "Y": 2}`,
+				ptr: ptrToMap(map[string]interface{}{"X": float32(3), "Y": int16(4), "Z": 1.5}),
+				out: ptrToMap(map[string]interface{}{"X": float64(1), "Y": float64(2), "Z": 1.5}),
+			},
+		}
+
+		for _, tt := range prefillTests {
+			ptrstr := fmt.Sprintf("%v", tt.ptr)
+			err := Unmarshal([]byte(tt.in), tt.ptr)
+			if err != nil {
+				GinkgoT().Errorf("Unmarshal: %v", err)
+			}
+			if !reflect.DeepEqual(tt.ptr, tt.out) {
+				GinkgoT().Errorf("Unmarshal(%#q, %s): have %v, want %v", tt.in, ptrstr, tt.ptr, tt.out)
+			}
+		}
+	})
+})
 
 type T struct {
 	X string
@@ -31,8 +484,6 @@ type V struct {
 	F3 Number
 }
 
-// ifaceNumAsFloat64/ifaceNumAsNumber are used to test unmarshaling with and
-// without UseNumber
 var ifaceNumAsFloat64 = map[string]interface{}{
 	"k1": float64(1),
 	"k2": "s",
@@ -51,14 +502,12 @@ type tx struct {
 	x int
 }
 
-// A type that can unmarshal itself.
-
 type unmarshaler struct {
 	T bool
 }
 
 func (u *unmarshaler) UnmarshalJSON(b []byte) error {
-	*u = unmarshaler{true} // All we need to see that UnmarshalJSON is called.
+	*u = unmarshaler{true}
 	return nil
 }
 
@@ -70,13 +519,12 @@ type unmarshalerText struct {
 	T bool
 }
 
-// needed for re-marshaling tests
 func (u *unmarshalerText) MarshalText() ([]byte, error) {
 	return []byte(""), nil
 }
 
 func (u *unmarshalerText) UnmarshalText(b []byte) error {
-	*u = unmarshalerText{true} // All we need to see that UnmarshalText is called.
+	*u = unmarshalerText{true}
 	return nil
 }
 
@@ -87,22 +535,20 @@ type ustructText struct {
 }
 
 var (
-	um0, um1 unmarshaler // target2 of unmarshaling
+	um0, um1 unmarshaler
 	ump      = &um1
 	umtrue   = unmarshaler{true}
 	umslice  = []unmarshaler{{true}}
 	umslicep = new([]unmarshaler)
 	umstruct = ustruct{unmarshaler{true}}
 
-	um0T, um1T unmarshalerText // target2 of unmarshaling
+	um0T, um1T unmarshalerText
 	umpT       = &um1T
 	umtrueT    = unmarshalerText{true}
 	umsliceT   = []unmarshalerText{{true}}
 	umslicepT  = new([]unmarshalerText)
 	umstructT  = ustructText{unmarshalerText{true}}
 )
-
-// Test data structures for anonymous fields.
 
 type Point struct {
 	Z int
@@ -112,28 +558,28 @@ type Top struct {
 	Level0 int
 	Embed0
 	*Embed0a
-	*Embed0b `force:"e,omitempty"` // treated as named
-	Embed0c  `force:"-"`           // ignored
+	*Embed0b `force:"e,omitempty"`
+	Embed0c  `force:"-"`
 	Loop
-	Embed0p // has Point with X, Y, used
-	Embed0q // has Point with Z, used
-	embed   // contains exported field
+	Embed0p
+	Embed0q
+	embed
 }
 
 type Embed0 struct {
-	Level1a int // overridden by Embed0a's Level1a with json tag
-	Level1b int // used because Embed0a's Level1b is renamed
-	Level1c int // used because Embed0a's Level1c is ignored
-	Level1d int // annihilated by Embed0a's Level1d
-	Level1e int `force:"x"` // annihilated by Embed0a.Level1e
+	Level1a int
+	Level1b int
+	Level1c int
+	Level1d int
+	Level1e int `force:"x"`
 }
 
 type Embed0a struct {
 	Level1a int `force:"Level1a,omitempty"`
 	Level1b int `force:"LEVEL1B,omitempty"`
 	Level1c int `force:"-"`
-	Level1d int // annihilated by Embed0's Level1d
-	Level1f int `force:"x"` // annihilated by Embed0's Level1e
+	Level1d int
+	Level1f int `force:"x"`
 }
 
 type Embed0b Embed0
@@ -158,8 +604,6 @@ type Loop struct {
 	*Loop
 }
 
-// From reflect test:
-// The X in S6 and S7 annihilate, but they also block the X in S8.S9.
 type S5 struct {
 	S6
 	S7
@@ -181,8 +625,6 @@ type S9 struct {
 	Y int
 }
 
-// From reflect test:
-// The X in S11.S6 and S12.S6 annihilate, but they also block the X in S13.S8.S9.
 type S10 struct {
 	S11
 	S12
@@ -210,7 +652,6 @@ type unmarshalTest struct {
 }
 
 type Ambig struct {
-	// Given "hello", the first match should win.
 	First  int `force:"HELLO"`
 	Second int `force:"Hello"`
 }
@@ -222,7 +663,7 @@ type XYZ struct {
 }
 
 var unmarshalTests = []unmarshalTest{
-	// basic types
+
 	{in: `true`, ptr: new(bool), out: true},
 	{in: `1`, ptr: new(int), out: 1},
 	{in: `1.2`, ptr: new(float64), out: 1.2},
@@ -243,26 +684,22 @@ var unmarshalTests = []unmarshalTest{
 	{in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(interface{}), out: ifaceNumAsFloat64},
 	{in: `{"k1":1,"k2":"s","k3":[1,2.0,3e-3],"k4":{"kk1":"s","kk2":2}}`, ptr: new(interface{}), out: ifaceNumAsNumber, useNumber: true},
 
-	// raw values with whitespace
 	{in: "\n true ", ptr: new(bool), out: true},
 	{in: "\t 1 ", ptr: new(int), out: 1},
 	{in: "\r 1.2 ", ptr: new(float64), out: 1.2},
 	{in: "\t -5 \n", ptr: new(int16), out: int16(-5)},
 	{in: "\t \"a\\u1234\" \n", ptr: new(string), out: "a\u1234"},
 
-	// Z has a "-" tag.
 	{in: `{"Y": 1, "Z": 2}`, ptr: new(T), out: T{Y: 1}},
 
 	{in: `{"alpha": "abc", "alphabet": "xyz"}`, ptr: new(U), out: U{Alphabet: "abc"}},
 	{in: `{"alpha": "abc"}`, ptr: new(U), out: U{Alphabet: "abc"}},
 	{in: `{"alphabet": "xyz"}`, ptr: new(U), out: U{}},
 
-	// syntax errors
 	{in: `{"X": "foo", "Y"}`, err: &SyntaxError{"invalid character '}' after object key", 17}},
 	{in: `[1, 2, 3+]`, err: &SyntaxError{"invalid character '+' after array element", 9}},
 	{in: `{"X":12x}`, err: &SyntaxError{"invalid character 'x' after object key:value pair", 8}, useNumber: true},
 
-	// raw value errors
 	{in: "\x01 42", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
 	{in: " 42 \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", 5}},
 	{in: "\x01 true", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
@@ -272,18 +709,15 @@ var unmarshalTests = []unmarshalTest{
 	{in: "\x01 \"string\"", err: &SyntaxError{"invalid character '\\x01' looking for beginning of value", 1}},
 	{in: " \"string\" \x01", err: &SyntaxError{"invalid character '\\x01' after top-level value", 11}},
 
-	// array tests
 	{in: `[1, 2, 3]`, ptr: new([3]int), out: [3]int{1, 2, 3}},
 	{in: `[1, 2, 3]`, ptr: new([1]int), out: [1]int{1}},
 	{in: `[1, 2, 3]`, ptr: new([5]int), out: [5]int{1, 2, 3, 0, 0}},
 
-	// empty array to interface test
 	{in: `[]`, ptr: new([]interface{}), out: []interface{}{}},
 	{in: `null`, ptr: new([]interface{}), out: []interface{}(nil)},
 	{in: `{"T":[]}`, ptr: new(map[string]interface{}), out: map[string]interface{}{"T": []interface{}{}}},
 	{in: `{"T":null}`, ptr: new(map[string]interface{}), out: map[string]interface{}{"T": interface{}(nil)}},
 
-	// composite tests
 	{in: allValueIndent, ptr: new(All), out: allValue},
 	{in: allValueCompact, ptr: new(All), out: allValue},
 	{in: allValueIndent, ptr: new(*All), out: &allValue},
@@ -293,15 +727,13 @@ var unmarshalTests = []unmarshalTest{
 	{in: pallValueIndent, ptr: new(*All), out: &pallValue},
 	{in: pallValueCompact, ptr: new(*All), out: &pallValue},
 
-	// unmarshal interface test
-	{in: `{"T":false}`, ptr: &um0, out: umtrue}, // use "false" so test will fail if custom unmarshaler is not called
+	{in: `{"T":false}`, ptr: &um0, out: umtrue},
 	{in: `{"T":false}`, ptr: &ump, out: &umtrue},
 	{in: `[{"T":false}]`, ptr: &umslice, out: umslice},
 	{in: `[{"T":false}]`, ptr: &umslicep, out: &umslice},
 	{in: `{"M":{"T":false}}`, ptr: &umstruct, out: umstruct},
 
-	// UnmarshalText interface test
-	{in: `"X"`, ptr: &um0T, out: umtrueT}, // use "false" so test will fail if custom unmarshaler is not called
+	{in: `"X"`, ptr: &um0T, out: umtrueT},
 	{in: `"X"`, ptr: &umpT, out: &umtrueT},
 	{in: `["X"]`, ptr: &umsliceT, out: umsliceT},
 	{in: `["X"]`, ptr: &umslicepT, out: &umsliceT},
@@ -379,7 +811,6 @@ var unmarshalTests = []unmarshalTest{
 		out: S10{S13: S13{S8: S8{S9: S9{Y: 2}}}},
 	},
 
-	// invalid UTF-8 is coerced to valid UTF-8.
 	{
 		in:  "\"hello\xffworld\"",
 		ptr: new(string),
@@ -417,28 +848,6 @@ var unmarshalTests = []unmarshalTest{
 	},
 }
 
-func TestMarshal(t *testing.T) {
-	b, err := Marshal(allValue)
-	if err != nil {
-		t.Fatalf("Marshal allValue: %v", err)
-	}
-	if string(b) != allValueCompact {
-		t.Errorf("Marshal allValueCompact")
-		diff(t, b, []byte(allValueCompact))
-		return
-	}
-
-	b, err = Marshal(pallValue)
-	if err != nil {
-		t.Fatalf("Marshal pallValue: %v", err)
-	}
-	if string(b) != pallValueCompact {
-		t.Errorf("Marshal pallValueCompact")
-		diff(t, b, []byte(pallValueCompact))
-		return
-	}
-}
-
 var badUTF8 = []struct {
 	in, out string
 }{
@@ -448,144 +857,6 @@ var badUTF8 = []struct {
 	{"\xff\xff", `"\ufffd\ufffd"`},
 	{"a\xffb", `"a\ufffdb"`},
 	{"\xe6\x97\xa5\xe6\x9c\xac\xff\xaa\x9e", `"日本\ufffd\ufffd\ufffd"`},
-}
-
-func TestMarshalBadUTF8(t *testing.T) {
-	for _, tt := range badUTF8 {
-		b, err := Marshal(tt.in)
-		if string(b) != tt.out || err != nil {
-			t.Errorf("Marshal(%q) = %#q, %v, want %#q, nil", tt.in, b, err, tt.out)
-		}
-	}
-}
-
-func TestMarshalNumberZeroVal(t *testing.T) {
-	var n Number
-	out, err := Marshal(n)
-	if err != nil {
-		t.Fatal(err)
-	}
-	outStr := string(out)
-	if outStr != "0" {
-		t.Fatalf("Invalid zero val for Number: %q", outStr)
-	}
-}
-
-func TestMarshalEmbeds(t *testing.T) {
-	top := &Top{
-		Level0: 1,
-		Embed0: Embed0{
-			Level1b: 2,
-			Level1c: 3,
-		},
-		Embed0a: &Embed0a{
-			Level1a: 5,
-			Level1b: 6,
-		},
-		Embed0b: &Embed0b{
-			Level1a: 8,
-			Level1b: 9,
-			Level1c: 10,
-			Level1d: 11,
-			Level1e: 12,
-		},
-		Loop: Loop{
-			Loop1: 13,
-			Loop2: 14,
-		},
-		Embed0p: Embed0p{
-			Point: image.Point{X: 15, Y: 16},
-		},
-		Embed0q: Embed0q{
-			Point: Point{Z: 17},
-		},
-		embed: embed{
-			Q: 18,
-		},
-	}
-	b, err := Marshal(top)
-	if err != nil {
-		t.Fatal(err)
-	}
-	want := "{\"Level0\":1,\"Level1b\":2,\"Level1c\":3,\"Level1a\":5,\"LEVEL1B\":6,\"e\":{\"Level1a\":8,\"Level1b\":9,\"Level1c\":10,\"Level1d\":11,\"x\":12},\"Loop1\":13,\"Loop2\":14,\"X\":15,\"Y\":16,\"Z\":17,\"Q\":18}"
-	if string(b) != want {
-		t.Errorf("Wrong marshal result.\n got: %q\nwant: %q", b, want)
-	}
-}
-
-func TestUnmarshal(t *testing.T) {
-	for i, tt := range unmarshalTests {
-		var scan scanner
-		in := []byte(tt.in)
-		if err := checkValid(in, &scan); err != nil {
-			if !reflect.DeepEqual(err, tt.err) {
-				t.Errorf("#%d: checkValid: %#v", i, err)
-				continue
-			}
-		}
-		if tt.ptr == nil {
-			continue
-		}
-		// v = new(right-type)
-		v := reflect.New(reflect.TypeOf(tt.ptr).Elem())
-		dec := NewDecoder(bytes.NewReader(in))
-		if tt.useNumber {
-			dec.UseNumber()
-		}
-		if err := dec.Decode(v.Interface()); !reflect.DeepEqual(err, tt.err) {
-			t.Errorf("#%d: %v want %v", i, err, tt.err)
-			continue
-		}
-		if !reflect.DeepEqual(v.Elem().Interface(), tt.out) {
-			t.Errorf("#%d: mismatch\nhave: %#+v\nwant: %#+v", i, v.Elem().Interface(), tt.out)
-			data, _ := Marshal(v.Elem().Interface())
-			println(string(data))
-			data, _ = Marshal(tt.out)
-			println(string(data))
-			continue
-		}
-
-		// Check round trip.
-		if tt.err == nil {
-			enc, err := Marshal(v.Interface())
-			if err != nil {
-				t.Errorf("#%d: error re-marshaling: %v", i, err)
-				continue
-			}
-			vv := reflect.New(reflect.TypeOf(tt.ptr).Elem())
-			dec = NewDecoder(bytes.NewReader(enc))
-			if tt.useNumber {
-				dec.UseNumber()
-			}
-			if err := dec.Decode(vv.Interface()); err != nil {
-				t.Errorf("#%d: error re-unmarshaling %#q: %v", i, enc, err)
-				continue
-			}
-			if !reflect.DeepEqual(v.Elem().Interface(), vv.Elem().Interface()) {
-				t.Errorf("#%d: mismatch\nhave: %#+v\nwant: %#+v", i, v.Elem().Interface(), vv.Elem().Interface())
-				t.Errorf("     In: %q", strings.Map(noSpace, string(in)))
-				t.Errorf("Marshal: %q", strings.Map(noSpace, string(enc)))
-				continue
-			}
-		}
-	}
-}
-
-func TestUnmarshalMarshal(t *testing.T) {
-	initBig()
-	var v interface{}
-	if err := Unmarshal(jsonBig, &v); err != nil {
-		t.Fatalf("Unmarshal: %v", err)
-	}
-	b, err := Marshal(v)
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
-	if !bytes.Equal(jsonBig, b) {
-		t.Errorf("Marshal jsonBig")
-		diff(t, b, jsonBig)
-		return
-	}
 }
 
 var numberTests = []struct {
@@ -600,84 +871,10 @@ var numberTests = []struct {
 	{in: "1e1000", intErr: "strconv.ParseInt: parsing \"1e1000\": invalid syntax", floatErr: "strconv.ParseFloat: parsing \"1e1000\": value out of range"},
 }
 
-// Independent of Decode, basic coverage of the accessors in Number
-func TestNumberAccessors(t *testing.T) {
-	for _, tt := range numberTests {
-		n := Number(tt.in)
-		if s := n.String(); s != tt.in {
-			t.Errorf("Number(%q).String() is %q", tt.in, s)
-		}
-		if i, err := n.Int64(); err == nil && tt.intErr == "" && i != tt.i {
-			t.Errorf("Number(%q).Int64() is %d", tt.in, i)
-		} else if (err == nil && tt.intErr != "") || (err != nil && err.Error() != tt.intErr) {
-			t.Errorf("Number(%q).Int64() wanted error %q but got: %v", tt.in, tt.intErr, err)
-		}
-		if f, err := n.Float64(); err == nil && tt.floatErr == "" && f != tt.f {
-			t.Errorf("Number(%q).Float64() is %g", tt.in, f)
-		} else if (err == nil && tt.floatErr != "") || (err != nil && err.Error() != tt.floatErr) {
-			t.Errorf("Number(%q).Float64() wanted error %q but got: %v", tt.in, tt.floatErr, err)
-		}
-	}
-}
-
-func TestLargeByteSlice(t *testing.T) {
-	s0 := make([]byte, 2000)
-	for i := range s0 {
-		s0[i] = byte(i)
-	}
-	b, err := Marshal(s0)
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
-	var s1 []byte
-	if err := Unmarshal(b, &s1); err != nil {
-		t.Fatalf("Unmarshal: %v", err)
-	}
-	if !bytes.Equal(s0, s1) {
-		t.Errorf("Marshal large byte slice")
-		diff(t, s0, s1)
-	}
-}
-
 type Xint struct {
 	X int
 }
 
-func TestUnmarshalInterface(t *testing.T) {
-	var xint Xint
-	var i interface{} = &xint
-	if err := Unmarshal([]byte(`{"X":1}`), &i); err != nil {
-		t.Fatalf("Unmarshal: %v", err)
-	}
-	if xint.X != 1 {
-		t.Fatalf("Did not write to xint")
-	}
-}
-
-func TestUnmarshalPtrPtr(t *testing.T) {
-	var xint Xint
-	pxint := &xint
-	if err := Unmarshal([]byte(`{"X":1}`), &pxint); err != nil {
-		t.Fatalf("Unmarshal: %v", err)
-	}
-	if xint.X != 1 {
-		t.Fatalf("Did not write to xint")
-	}
-}
-
-func TestEscape(t *testing.T) {
-	const input = `"foobar"<html>` + " [\u2028 \u2029]"
-	const expected = `"\"foobar\"\u003chtml\u003e [\u2028 \u2029]"`
-	b, err := Marshal(input)
-	if err != nil {
-		t.Fatalf("Marshal error: %v", err)
-	}
-	if s := string(b); s != expected {
-		t.Errorf("Encoding of [%s]:\n got [%s]\nwant [%s]", input, s, expected)
-	}
-}
-
-// WrongString is a struct that's misusing the ,string modifier.
 type WrongString struct {
 	Message string `force:"result,string"`
 }
@@ -690,20 +887,6 @@ var wrongStringTests = []wrongStringTest{
 	{`{"result":"x"}`, `force: invalid use of ,string struct tag, trying to unmarshal "x" into string`},
 	{`{"result":"foo"}`, `force: invalid use of ,string struct tag, trying to unmarshal "foo" into string`},
 	{`{"result":"123"}`, `force: invalid use of ,string struct tag, trying to unmarshal "123" into string`},
-}
-
-// If people misuse the ,string modifier, the error message should be
-// helpful, telling the user that they're doing it wrong.
-func TestErrorMessageFromMisusedString(t *testing.T) {
-	for n, tt := range wrongStringTests {
-		r := strings.NewReader(tt.in)
-		var s WrongString
-		err := NewDecoder(r).Decode(&s)
-		got := fmt.Sprintf("%v", err)
-		if got != tt.err {
-			t.Errorf("%d. got err = %q, want %q", n, got, tt.err)
-		}
-	}
 }
 
 func noSpace(c rune) rune {
@@ -1027,51 +1210,6 @@ var pallValueIndent = `{
 
 var pallValueCompact = strings.Map(noSpace, pallValueIndent)
 
-func TestRefUnmarshal(t *testing.T) {
-	type S struct {
-		// Ref is defined in encode_test.go.
-		R0 Ref
-		R1 *Ref
-		R2 RefText
-		R3 *RefText
-	}
-	want := S{
-		R0: 12,
-		R1: new(Ref),
-		R2: 13,
-		R3: new(RefText),
-	}
-	*want.R1 = 12
-	*want.R3 = 13
-
-	var got S
-	if err := Unmarshal([]byte(`{"R0":"ref","R1":"ref","R2":"ref","R3":"ref"}`), &got); err != nil {
-		t.Fatalf("Unmarshal: %v", err)
-	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("got %+v, want %+v", got, want)
-	}
-}
-
-// Test that the empty string doesn't panic decoding when ,string is specified
-// Issue 3450
-func TestEmptyString(t *testing.T) {
-	type T2 struct {
-		Number1 int `force:",string"`
-		Number2 int `force:",string"`
-	}
-	data := `{"Number1":"1", "Number2":""}`
-	dec := NewDecoder(strings.NewReader(data))
-	var t2 T2
-	err := dec.Decode(&t2)
-	if err == nil {
-		t.Fatal("Decode: did not return error")
-	}
-	if t2.Number1 != 1 {
-		t.Fatal("Decode: did not set Number1")
-	}
-}
-
 func intp(x int) *int {
 	p := new(int)
 	*p = x
@@ -1104,111 +1242,16 @@ var interfaceSetTests = []struct {
 	{intpp(intp(1)), `null`, intpp(nil)},
 }
 
-func TestInterfaceSet(t *testing.T) {
-	for _, tt := range interfaceSetTests {
-		b := struct{ X interface{} }{tt.pre}
-		blob := `{"X":` + tt.json + `}`
-		if err := Unmarshal([]byte(blob), &b); err != nil {
-			t.Errorf("Unmarshal %#q: %v", blob, err)
-			continue
-		}
-		if !reflect.DeepEqual(b.X, tt.post) {
-			t.Errorf("Unmarshal %#q into %#v: X=%#v, want %#v", blob, tt.pre, b.X, tt.post)
-		}
-	}
-}
-
-// JSON null values should be ignored for primitives and string values instead of resulting in an error.
-// Issue 2540
-func TestUnmarshalNulls(t *testing.T) {
-	jsonData := []byte(`{
-		"Bool"    : null, 
-		"Int"     : null, 
-		"Int8"    : null,
-		"Int16"   : null,
-		"Int32"   : null,
-		"Int64"   : null,
-		"Uint"    : null,
-		"Uint8"   : null,
-		"Uint16"  : null,
-		"Uint32"  : null,
-		"Uint64"  : null,
-		"Float32" : null,
-		"Float64" : null,
-		"String"  : null}`)
-
-	nulls := All{
-		Bool:    true,
-		Int:     2,
-		Int8:    3,
-		Int16:   4,
-		Int32:   5,
-		Int64:   6,
-		Uint:    7,
-		Uint8:   8,
-		Uint16:  9,
-		Uint32:  10,
-		Uint64:  11,
-		Float32: 12.1,
-		Float64: 13.1,
-		String:  "14"}
-
-	err := Unmarshal(jsonData, &nulls)
-	if err != nil {
-		t.Errorf("Unmarshal of null values failed: %v", err)
-	}
-	if !nulls.Bool || nulls.Int != 2 || nulls.Int8 != 3 || nulls.Int16 != 4 || nulls.Int32 != 5 || nulls.Int64 != 6 ||
-		nulls.Uint != 7 || nulls.Uint8 != 8 || nulls.Uint16 != 9 || nulls.Uint32 != 10 || nulls.Uint64 != 11 ||
-		nulls.Float32 != 12.1 || nulls.Float64 != 13.1 || nulls.String != "14" {
-
-		t.Errorf("Unmarshal of null values affected primitives")
-	}
-}
-
-func TestStringKind(t *testing.T) {
-	type stringKind string
-
-	var m1, m2 map[stringKind]int
-	m1 = map[stringKind]int{
-		"foo": 42,
-	}
-
-	data, err := Marshal(m1)
-	if err != nil {
-		t.Errorf("Unexpected error marshalling: %v", err)
-	}
-
-	err = Unmarshal(data, &m2)
-	if err != nil {
-		t.Errorf("Unexpected error unmarshalling: %v", err)
-	}
-
-	if !reflect.DeepEqual(m1, m2) {
-		t.Error("Items should be equal after encoding and then decoding")
-	}
-
-}
-
 var decodeTypeErrorTests = []struct {
 	dest interface{}
 	src  string
 }{
-	{new(string), `{"user": "name"}`}, // issue 4628.
-	{new(error), `{}`},                // issue 4222
+	{new(string), `{"user": "name"}`},
+	{new(error), `{}`},
 	{new(error), `[]`},
 	{new(error), `""`},
 	{new(error), `123`},
 	{new(error), `true`},
-}
-
-func TestUnmarshalTypeError(t *testing.T) {
-	for _, item := range decodeTypeErrorTests {
-		err := Unmarshal([]byte(item.src), item.dest)
-		if _, ok := err.(*UnmarshalTypeError); !ok {
-			t.Errorf("expected type error for Unmarshal(%q, type %T): got %T",
-				item.src, item.dest, err)
-		}
-	}
 }
 
 var unmarshalSyntaxTests = []string{
@@ -1222,40 +1265,12 @@ var unmarshalSyntaxTests = []string{
 	`{"key":1,`,
 }
 
-func TestUnmarshalSyntax(t *testing.T) {
-	var x interface{}
-	for _, src := range unmarshalSyntaxTests {
-		err := Unmarshal([]byte(src), &x)
-		if _, ok := err.(*SyntaxError); !ok {
-			t.Errorf("expected syntax error for Unmarshal(%q): got %T", src, err)
-		}
-	}
-}
-
-// Test handling of unexported fields that should be ignored.
-// Issue 4660
 type unexportedFields struct {
 	Name string
 	m    map[string]interface{} `force:"-"`
 	m2   map[string]interface{} `force:"abcd"`
 }
 
-func TestUnmarshalUnexported(t *testing.T) {
-	input := `{"Name": "Bob", "m": {"x": 123}, "m2": {"y": 456}, "abcd": {"z": 789}}`
-	want := &unexportedFields{Name: "Bob"}
-
-	out := &unexportedFields{}
-	err := Unmarshal([]byte(input), out)
-	if err != nil {
-		t.Errorf("got error %v, expected nil", err)
-	}
-	if !reflect.DeepEqual(out, want) {
-		t.Errorf("got %q, want %q", out, want)
-	}
-}
-
-// Time3339 is a time.Time which encodes to and from JSON
-// as an RFC 3339 time in UTC.
 type Time3339 time.Time
 
 func (t *Time3339) UnmarshalJSON(b []byte) error {
@@ -1268,63 +1283,4 @@ func (t *Time3339) UnmarshalJSON(b []byte) error {
 	}
 	*t = Time3339(tm)
 	return nil
-}
-
-func TestUnmarshalJSONLiteralError(t *testing.T) {
-	var t3 Time3339
-	err := Unmarshal([]byte(`"0000-00-00T00:00:00Z"`), &t3)
-	if err == nil {
-		t.Fatalf("expected error; got time %v", time.Time(t3))
-	}
-	if !strings.Contains(err.Error(), "range") {
-		t.Errorf("got err = %v; want out of range error", err)
-	}
-}
-
-// Test that extra object elements in an array do not result in a
-// "data changing underfoot" error.
-// Issue 3717
-func TestSkipArrayObjects(t *testing.T) {
-	json := `[{}]`
-	var dest [0]interface{}
-
-	err := Unmarshal([]byte(json), &dest)
-	if err != nil {
-		t.Errorf("got error %q, want nil", err)
-	}
-}
-
-// Test semantics of pre-filled struct fields and pre-filled map fields.
-// Issue 4900.
-func TestPrefilled(t *testing.T) {
-	ptrToMap := func(m map[string]interface{}) *map[string]interface{} { return &m }
-
-	// Values here change, cannot reuse table across runs.
-	var prefillTests = []struct {
-		in  string
-		ptr interface{}
-		out interface{}
-	}{
-		{
-			in:  `{"X": 1, "Y": 2}`,
-			ptr: &XYZ{X: float32(3), Y: int16(4), Z: 1.5},
-			out: &XYZ{X: float64(1), Y: float64(2), Z: 1.5},
-		},
-		{
-			in:  `{"X": 1, "Y": 2}`,
-			ptr: ptrToMap(map[string]interface{}{"X": float32(3), "Y": int16(4), "Z": 1.5}),
-			out: ptrToMap(map[string]interface{}{"X": float64(1), "Y": float64(2), "Z": 1.5}),
-		},
-	}
-
-	for _, tt := range prefillTests {
-		ptrstr := fmt.Sprintf("%v", tt.ptr)
-		err := Unmarshal([]byte(tt.in), tt.ptr) // tt.ptr edited here
-		if err != nil {
-			t.Errorf("Unmarshal: %v", err)
-		}
-		if !reflect.DeepEqual(tt.ptr, tt.out) {
-			t.Errorf("Unmarshal(%#q, %s): have %v, want %v", tt.in, ptrstr, tt.ptr, tt.out)
-		}
-	}
 }

--- a/forcejson/encode_test.go
+++ b/forcejson/encode_test.go
@@ -1,23 +1,292 @@
-// Copyright 2011 The Go Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package forcejson
 
 import (
 	"bytes"
 	"math"
 	"reflect"
-	"testing"
+
+	. "github.com/onsi/ginkgo"
 	"unicode"
 )
+
+var _ = Describe("Testing with Ginkgo", func() {
+	It("omit empty", func() {
+
+		var o Optionals
+		o.Sw = "something"
+		o.Mr = map[string]interface{}{}
+		o.Mo = map[string]interface{}{}
+
+		got, err := MarshalIndent(&o, "", " ")
+		if err != nil {
+			GinkgoT().Fatal(err)
+		}
+		if got := string(got); got != optionalsExpected {
+			GinkgoT().Errorf(" got: %s\nwant: %s\n", got, optionalsExpected)
+		}
+	})
+	It("string tag", func() {
+
+		var s StringTag
+		s.BoolStr = true
+		s.IntStr = 42
+		s.StrStr = "xzbit"
+		got, err := MarshalIndent(&s, "", " ")
+		if err != nil {
+			GinkgoT().Fatal(err)
+		}
+		if got := string(got); got != stringTagExpected {
+			GinkgoT().Fatalf(" got: %s\nwant: %s\n", got, stringTagExpected)
+		}
+
+		var s2 StringTag
+		err = NewDecoder(bytes.NewBuffer(got)).Decode(&s2)
+		if err != nil {
+			GinkgoT().Fatalf("Decode: %v", err)
+		}
+		if !reflect.DeepEqual(s, s2) {
+			GinkgoT().Fatalf("decode didn't match.\nsource: %#v\nEncoded as:\n%s\ndecode: %#v", s, string(got), s2)
+		}
+	})
+	It("encode renamed byte slice", func() {
+
+		s := renamedByteSlice("abc")
+		result, err := Marshal(s)
+		if err != nil {
+			GinkgoT().Fatal(err)
+		}
+		expect := `"YWJj"`
+		if string(result) != expect {
+			GinkgoT().Errorf(" got %s want %s", result, expect)
+		}
+		r := renamedRenamedByteSlice("abc")
+		result, err = Marshal(r)
+		if err != nil {
+			GinkgoT().Fatal(err)
+		}
+		if string(result) != expect {
+			GinkgoT().Errorf(" got %s want %s", result, expect)
+		}
+	})
+	It("unsupported values", func() {
+
+		for _, v := range unsupportedValues {
+			if _, err := Marshal(v); err != nil {
+				if _, ok := err.(*UnsupportedValueError); !ok {
+					GinkgoT().Errorf("for %v, got %T want UnsupportedValueError", v, err)
+				}
+			} else {
+				GinkgoT().Errorf("for %v, expected error", v)
+			}
+		}
+	})
+	It("ref val marshal", func() {
+
+		var s = struct {
+			R0 Ref
+			R1 *Ref
+			R2 RefText
+			R3 *RefText
+			V0 Val
+			V1 *Val
+			V2 ValText
+			V3 *ValText
+		}{
+			R0: 12,
+			R1: new(Ref),
+			R2: 14,
+			R3: new(RefText),
+			V0: 13,
+			V1: new(Val),
+			V2: 15,
+			V3: new(ValText),
+		}
+		const want = `{"R0":"ref","R1":"ref","R2":"\"ref\"","R3":"\"ref\"","V0":"val","V1":"val","V2":"\"val\"","V3":"\"val\""}`
+		b, err := Marshal(&s)
+		if err != nil {
+			GinkgoT().Fatalf("Marshal: %v", err)
+		}
+		if got := string(b); got != want {
+			GinkgoT().Errorf("got %q, want %q", got, want)
+		}
+	})
+	It("marshaler escaping", func() {
+
+		var c C
+		want := `"\u003c\u0026\u003e"`
+		b, err := Marshal(c)
+		if err != nil {
+			GinkgoT().Fatalf("Marshal(c): %v", err)
+		}
+		if got := string(b); got != want {
+			GinkgoT().Errorf("Marshal(c) = %#q, want %#q", got, want)
+		}
+
+		var ct CText
+		want = `"\"\u003c\u0026\u003e\""`
+		b, err = Marshal(ct)
+		if err != nil {
+			GinkgoT().Fatalf("Marshal(ct): %v", err)
+		}
+		if got := string(b); got != want {
+			GinkgoT().Errorf("Marshal(ct) = %#q, want %#q", got, want)
+		}
+	})
+	It("anonymous nonstruct", func() {
+
+		var i IntType = 11
+		a := MyStruct{i}
+		const want = `{"IntType":11}`
+
+		b, err := Marshal(a)
+		if err != nil {
+			GinkgoT().Fatalf("Marshal: %v", err)
+		}
+		if got := string(b); got != want {
+			GinkgoT().Errorf("got %q, want %q", got, want)
+		}
+	})
+	It("embedded bug", func() {
+
+		v := BugB{
+			BugA{"A"},
+			"B",
+		}
+		b, err := Marshal(v)
+		if err != nil {
+			GinkgoT().Fatal("Marshal:", err)
+		}
+		want := `{"S":"B"}`
+		got := string(b)
+		if got != want {
+			GinkgoT().Fatalf("Marshal: got %s want %s", got, want)
+		}
+
+		x := BugX{
+			A: 23,
+		}
+		b, err = Marshal(x)
+		if err != nil {
+			GinkgoT().Fatal("Marshal:", err)
+		}
+		want = `{"A":23}`
+		got = string(b)
+		if got != want {
+			GinkgoT().Fatalf("Marshal: got %s want %s", got, want)
+		}
+	})
+	It("tagged field dominates", func() {
+
+		v := BugY{
+			BugA{"BugA"},
+			BugD{"BugD"},
+		}
+		b, err := Marshal(v)
+		if err != nil {
+			GinkgoT().Fatal("Marshal:", err)
+		}
+		want := `{"S":"BugD"}`
+		got := string(b)
+		if got != want {
+			GinkgoT().Fatalf("Marshal: got %s want %s", got, want)
+		}
+	})
+	It("duplicated field disappears", func() {
+
+		v := BugZ{
+			BugA{"BugA"},
+			BugC{"BugC"},
+			BugY{
+				BugA{"nested BugA"},
+				BugD{"nested BugD"},
+			},
+		}
+		b, err := Marshal(v)
+		if err != nil {
+			GinkgoT().Fatal("Marshal:", err)
+		}
+		want := `{}`
+		got := string(b)
+		if got != want {
+			GinkgoT().Fatalf("Marshal: got %s want %s", got, want)
+		}
+	})
+	It("string bytes", func() {
+
+		es := &encodeState{}
+		var r []rune
+		for i := '\u0000'; i <= unicode.MaxRune; i++ {
+			r = append(r, i)
+		}
+		s := string(r) + "\xff\xff\xffhello"
+		_, err := es.string(s)
+		if err != nil {
+			GinkgoT().Fatal(err)
+		}
+
+		esBytes := &encodeState{}
+		_, err = esBytes.stringBytes([]byte(s))
+		if err != nil {
+			GinkgoT().Fatal(err)
+		}
+
+		enc := es.Buffer.String()
+		encBytes := esBytes.Buffer.String()
+		if enc != encBytes {
+			i := 0
+			for i < len(enc) && i < len(encBytes) && enc[i] == encBytes[i] {
+				i++
+			}
+			enc = enc[i:]
+			encBytes = encBytes[i:]
+			i = 0
+			for i < len(enc) && i < len(encBytes) && enc[len(enc)-i-1] == encBytes[len(encBytes)-i-1] {
+				i++
+			}
+			enc = enc[:len(enc)-i]
+			encBytes = encBytes[:len(encBytes)-i]
+
+			if len(enc) > 20 {
+				enc = enc[:20] + "..."
+			}
+			if len(encBytes) > 20 {
+				encBytes = encBytes[:20] + "..."
+			}
+			GinkgoT().Errorf("encodings differ at %#q vs %#q", enc, encBytes)
+		}
+	})
+	It("issue6458", func() {
+
+		type Foo struct {
+			M RawMessage
+		}
+		x := Foo{RawMessage(`"foo"`)}
+
+		b, err := Marshal(&x)
+		if err != nil {
+			GinkgoT().Fatal(err)
+		}
+		if want := `{"M":"foo"}`; string(b) != want {
+			GinkgoT().Errorf("Marshal(&x) = %#q; want %#q", b, want)
+		}
+
+		b, err = Marshal(x)
+		if err != nil {
+			GinkgoT().Fatal(err)
+		}
+
+		if want := `{"M":"ImZvbyI="}`; string(b) != want {
+			GinkgoT().Errorf("Marshal(x) = %#q; want %#q", b, want)
+		}
+	})
+})
 
 type Optionals struct {
 	Sr string `force:"sr"`
 	So string `force:"so,omitempty"`
 	Sw string `force:"-"`
 
-	Ir int `force:"omitempty"` // actually named omitempty, not an option
+	Ir int `force:"omitempty"`
 	Io int `force:"io,omitempty"`
 
 	Slr []string `force:"slr,random"`
@@ -34,21 +303,6 @@ var optionalsExpected = `{
  "mr": {}
 }`
 
-func TestOmitEmpty(t *testing.T) {
-	var o Optionals
-	o.Sw = "something"
-	o.Mr = map[string]interface{}{}
-	o.Mo = map[string]interface{}{}
-
-	got, err := MarshalIndent(&o, "", " ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := string(got); got != optionalsExpected {
-		t.Errorf(" got: %s\nwant: %s\n", got, optionalsExpected)
-	}
-}
-
 type StringTag struct {
 	BoolStr bool   `force:",string"`
 	IntStr  int64  `force:",string"`
@@ -61,54 +315,9 @@ var stringTagExpected = `{
  "StrStr": "\"xzbit\""
 }`
 
-func TestStringTag(t *testing.T) {
-	var s StringTag
-	s.BoolStr = true
-	s.IntStr = 42
-	s.StrStr = "xzbit"
-	got, err := MarshalIndent(&s, "", " ")
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got := string(got); got != stringTagExpected {
-		t.Fatalf(" got: %s\nwant: %s\n", got, stringTagExpected)
-	}
-
-	// Verify that it round-trips.
-	var s2 StringTag
-	err = NewDecoder(bytes.NewBuffer(got)).Decode(&s2)
-	if err != nil {
-		t.Fatalf("Decode: %v", err)
-	}
-	if !reflect.DeepEqual(s, s2) {
-		t.Fatalf("decode didn't match.\nsource: %#v\nEncoded as:\n%s\ndecode: %#v", s, string(got), s2)
-	}
-}
-
-// byte slices are special even if they're renamed types.
 type renamedByte byte
 type renamedByteSlice []byte
 type renamedRenamedByteSlice []renamedByte
-
-func TestEncodeRenamedByteSlice(t *testing.T) {
-	s := renamedByteSlice("abc")
-	result, err := Marshal(s)
-	if err != nil {
-		t.Fatal(err)
-	}
-	expect := `"YWJj"`
-	if string(result) != expect {
-		t.Errorf(" got %s want %s", result, expect)
-	}
-	r := renamedRenamedByteSlice("abc")
-	result, err = Marshal(r)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(result) != expect {
-		t.Errorf(" got %s want %s", result, expect)
-	}
-}
 
 var unsupportedValues = []interface{}{
 	math.NaN(),
@@ -116,19 +325,6 @@ var unsupportedValues = []interface{}{
 	math.Inf(1),
 }
 
-func TestUnsupportedValues(t *testing.T) {
-	for _, v := range unsupportedValues {
-		if _, err := Marshal(v); err != nil {
-			if _, ok := err.(*UnsupportedValueError); !ok {
-				t.Errorf("for %v, got %T want UnsupportedValueError", v, err)
-			}
-		} else {
-			t.Errorf("for %v, expected error", v)
-		}
-	}
-}
-
-// Ref has Marshaler and Unmarshaler methods with pointer receiver.
 type Ref int
 
 func (*Ref) MarshalJSON() ([]byte, error) {
@@ -140,14 +336,12 @@ func (r *Ref) UnmarshalJSON([]byte) error {
 	return nil
 }
 
-// Val has Marshaler methods with value receiver.
 type Val int
 
 func (Val) MarshalJSON() ([]byte, error) {
 	return []byte(`"val"`), nil
 }
 
-// RefText has Marshaler and Unmarshaler methods with pointer receiver.
 type RefText int
 
 func (*RefText) MarshalText() ([]byte, error) {
@@ -159,97 +353,28 @@ func (r *RefText) UnmarshalText([]byte) error {
 	return nil
 }
 
-// ValText has Marshaler methods with value receiver.
 type ValText int
 
 func (ValText) MarshalText() ([]byte, error) {
 	return []byte(`"val"`), nil
 }
 
-func TestRefValMarshal(t *testing.T) {
-	var s = struct {
-		R0 Ref
-		R1 *Ref
-		R2 RefText
-		R3 *RefText
-		V0 Val
-		V1 *Val
-		V2 ValText
-		V3 *ValText
-	}{
-		R0: 12,
-		R1: new(Ref),
-		R2: 14,
-		R3: new(RefText),
-		V0: 13,
-		V1: new(Val),
-		V2: 15,
-		V3: new(ValText),
-	}
-	const want = `{"R0":"ref","R1":"ref","R2":"\"ref\"","R3":"\"ref\"","V0":"val","V1":"val","V2":"\"val\"","V3":"\"val\""}`
-	b, err := Marshal(&s)
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
-	if got := string(b); got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
-}
-
-// C implements Marshaler and returns unescaped JSON.
 type C int
 
 func (C) MarshalJSON() ([]byte, error) {
 	return []byte(`"<&>"`), nil
 }
 
-// CText implements Marshaler and returns unescaped text.
 type CText int
 
 func (CText) MarshalText() ([]byte, error) {
 	return []byte(`"<&>"`), nil
 }
 
-func TestMarshalerEscaping(t *testing.T) {
-	var c C
-	want := `"\u003c\u0026\u003e"`
-	b, err := Marshal(c)
-	if err != nil {
-		t.Fatalf("Marshal(c): %v", err)
-	}
-	if got := string(b); got != want {
-		t.Errorf("Marshal(c) = %#q, want %#q", got, want)
-	}
-
-	var ct CText
-	want = `"\"\u003c\u0026\u003e\""`
-	b, err = Marshal(ct)
-	if err != nil {
-		t.Fatalf("Marshal(ct): %v", err)
-	}
-	if got := string(b); got != want {
-		t.Errorf("Marshal(ct) = %#q, want %#q", got, want)
-	}
-}
-
 type IntType int
 
 type MyStruct struct {
 	IntType
-}
-
-func TestAnonymousNonstruct(t *testing.T) {
-	var i IntType = 11
-	a := MyStruct{i}
-	const want = `{"IntType":11}`
-
-	b, err := Marshal(a)
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
-	if got := string(b); got != want {
-		t.Errorf("got %q, want %q", got, want)
-	}
 }
 
 type BugA struct {
@@ -265,163 +390,23 @@ type BugC struct {
 	S string
 }
 
-// Legal Go: We never use the repeated embedded field (S).
 type BugX struct {
 	A int
 	BugA
 	BugB
 }
 
-// Issue 5245.
-func TestEmbeddedBug(t *testing.T) {
-	v := BugB{
-		BugA{"A"},
-		"B",
-	}
-	b, err := Marshal(v)
-	if err != nil {
-		t.Fatal("Marshal:", err)
-	}
-	want := `{"S":"B"}`
-	got := string(b)
-	if got != want {
-		t.Fatalf("Marshal: got %s want %s", got, want)
-	}
-	// Now check that the duplicate field, S, does not appear.
-	x := BugX{
-		A: 23,
-	}
-	b, err = Marshal(x)
-	if err != nil {
-		t.Fatal("Marshal:", err)
-	}
-	want = `{"A":23}`
-	got = string(b)
-	if got != want {
-		t.Fatalf("Marshal: got %s want %s", got, want)
-	}
-}
-
-type BugD struct { // Same as BugA after tagging.
+type BugD struct {
 	XXX string `force:"S"`
 }
 
-// BugD's tagged S field should dominate BugA's.
 type BugY struct {
 	BugA
 	BugD
 }
 
-// Test that a field with a tag dominates untagged fields.
-func TestTaggedFieldDominates(t *testing.T) {
-	v := BugY{
-		BugA{"BugA"},
-		BugD{"BugD"},
-	}
-	b, err := Marshal(v)
-	if err != nil {
-		t.Fatal("Marshal:", err)
-	}
-	want := `{"S":"BugD"}`
-	got := string(b)
-	if got != want {
-		t.Fatalf("Marshal: got %s want %s", got, want)
-	}
-}
-
-// There are no tags here, so S should not appear.
 type BugZ struct {
 	BugA
 	BugC
-	BugY // Contains a tagged S field through BugD; should not dominate.
-}
-
-func TestDuplicatedFieldDisappears(t *testing.T) {
-	v := BugZ{
-		BugA{"BugA"},
-		BugC{"BugC"},
-		BugY{
-			BugA{"nested BugA"},
-			BugD{"nested BugD"},
-		},
-	}
-	b, err := Marshal(v)
-	if err != nil {
-		t.Fatal("Marshal:", err)
-	}
-	want := `{}`
-	got := string(b)
-	if got != want {
-		t.Fatalf("Marshal: got %s want %s", got, want)
-	}
-}
-
-func TestStringBytes(t *testing.T) {
-	// Test that encodeState.stringBytes and encodeState.string use the same encoding.
-	es := &encodeState{}
-	var r []rune
-	for i := '\u0000'; i <= unicode.MaxRune; i++ {
-		r = append(r, i)
-	}
-	s := string(r) + "\xff\xff\xffhello" // some invalid UTF-8 too
-	_, err := es.string(s)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	esBytes := &encodeState{}
-	_, err = esBytes.stringBytes([]byte(s))
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	enc := es.Buffer.String()
-	encBytes := esBytes.Buffer.String()
-	if enc != encBytes {
-		i := 0
-		for i < len(enc) && i < len(encBytes) && enc[i] == encBytes[i] {
-			i++
-		}
-		enc = enc[i:]
-		encBytes = encBytes[i:]
-		i = 0
-		for i < len(enc) && i < len(encBytes) && enc[len(enc)-i-1] == encBytes[len(encBytes)-i-1] {
-			i++
-		}
-		enc = enc[:len(enc)-i]
-		encBytes = encBytes[:len(encBytes)-i]
-
-		if len(enc) > 20 {
-			enc = enc[:20] + "..."
-		}
-		if len(encBytes) > 20 {
-			encBytes = encBytes[:20] + "..."
-		}
-
-		t.Errorf("encodings differ at %#q vs %#q", enc, encBytes)
-	}
-}
-
-func TestIssue6458(t *testing.T) {
-	type Foo struct {
-		M RawMessage
-	}
-	x := Foo{RawMessage(`"foo"`)}
-
-	b, err := Marshal(&x)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if want := `{"M":"foo"}`; string(b) != want {
-		t.Errorf("Marshal(&x) = %#q; want %#q", b, want)
-	}
-
-	b, err = Marshal(x)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if want := `{"M":"ImZvbyI="}`; string(b) != want {
-		t.Errorf("Marshal(x) = %#q; want %#q", b, want)
-	}
+	BugY
 }

--- a/forcejson/example_test.go
+++ b/forcejson/example_test.go
@@ -1,7 +1,3 @@
-// Copyright 2011 The Go Authors.  All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package forcejson_test
 
 import (
@@ -11,7 +7,12 @@ import (
 	"log"
 	"os"
 	"strings"
+
+	. "github.com/onsi/ginkgo"
 )
+
+var _ = Describe("Testing with Ginkgo", func() {
+})
 
 func ExampleMarshal() {
 	type ColorGroup struct {
@@ -29,8 +30,7 @@ func ExampleMarshal() {
 		fmt.Println("error:", err)
 	}
 	os.Stdout.Write(b)
-	// Output:
-	// {"ID":1,"Name":"Reds","Colors":["Crimson","Red","Ruby","Maroon"]}
+
 }
 
 func ExampleUnmarshal() {
@@ -48,11 +48,9 @@ func ExampleUnmarshal() {
 		fmt.Println("error:", err)
 	}
 	fmt.Printf("%+v", animals)
-	// Output:
-	// [{Name:Platypus Order:Monotremata} {Name:Quoll Order:Dasyuromorphia}]
+
 }
 
-// This example uses a Decoder to decode a stream of distinct JSON values.
 func ExampleDecoder() {
 	const jsonStream = `
 		{"Name": "Ed", "Text": "Knock knock."}
@@ -74,19 +72,13 @@ func ExampleDecoder() {
 		}
 		fmt.Printf("%s: %s\n", m.Name, m.Text)
 	}
-	// Output:
-	// Ed: Knock knock.
-	// Sam: Who's there?
-	// Ed: Go fmt.
-	// Sam: Go fmt who?
-	// Ed: Go fmt yourself!
+
 }
 
-// This example uses RawMessage to delay parsing part of a JSON message.
 func ExampleRawMessage() {
 	type Color struct {
 		Space string
-		Point json.RawMessage // delay parsing until we know the color space
+		Point json.RawMessage
 	}
 	type RGB struct {
 		R uint8
@@ -123,7 +115,5 @@ func ExampleRawMessage() {
 		}
 		fmt.Println(c.Space, dst)
 	}
-	// Output:
-	// YCbCr &{255 0 -10}
-	// RGB &{98 218 255}
+
 }

--- a/forcejson/forcejson_suite_test.go
+++ b/forcejson/forcejson_suite_test.go
@@ -1,0 +1,13 @@
+package forcejson_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestForcejson(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Forcejson Suite")
+}

--- a/forcejson/scanner_test.go
+++ b/forcejson/scanner_test.go
@@ -1,7 +1,3 @@
-// Copyright 2010 The Go Authors.  All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package forcejson
 
 import (
@@ -10,9 +6,156 @@ import (
 	"math/rand"
 	"reflect"
 	"testing"
+
+	. "github.com/onsi/ginkgo"
 )
 
-// Tests of simple examples.
+var _ = Describe("Testing with Ginkgo", func() {
+	It("compact", func() {
+
+		var buf bytes.Buffer
+		for _, tt := range examples {
+			buf.Reset()
+			if err := Compact(&buf, []byte(tt.compact)); err != nil {
+				GinkgoT().Errorf("Compact(%#q): %v", tt.compact, err)
+			} else if s := buf.String(); s != tt.compact {
+				GinkgoT().Errorf("Compact(%#q) = %#q, want original", tt.compact, s)
+			}
+
+			buf.Reset()
+			if err := Compact(&buf, []byte(tt.indent)); err != nil {
+				GinkgoT().Errorf("Compact(%#q): %v", tt.indent, err)
+				continue
+			} else if s := buf.String(); s != tt.compact {
+				GinkgoT().Errorf("Compact(%#q) = %#q, want %#q", tt.indent, s, tt.compact)
+			}
+		}
+	})
+	It("compact separators", func() {
+
+		tests := []struct {
+			in, compact string
+		}{
+			{"{\"\u2028\": 1}", `{"\u2028":1}`},
+			{"{\"\u2029\" :2}", `{"\u2029":2}`},
+		}
+		for _, tt := range tests {
+			var buf bytes.Buffer
+			if err := Compact(&buf, []byte(tt.in)); err != nil {
+				GinkgoT().Errorf("Compact(%q): %v", tt.in, err)
+			} else if s := buf.String(); s != tt.compact {
+				GinkgoT().Errorf("Compact(%q) = %q, want %q", tt.in, s, tt.compact)
+			}
+		}
+	})
+	It("indent", func() {
+
+		var buf bytes.Buffer
+		for _, tt := range examples {
+			buf.Reset()
+			if err := Indent(&buf, []byte(tt.indent), "", "\t"); err != nil {
+				GinkgoT().Errorf("Indent(%#q): %v", tt.indent, err)
+			} else if s := buf.String(); s != tt.indent {
+				GinkgoT().Errorf("Indent(%#q) = %#q, want original", tt.indent, s)
+			}
+
+			buf.Reset()
+			if err := Indent(&buf, []byte(tt.compact), "", "\t"); err != nil {
+				GinkgoT().Errorf("Indent(%#q): %v", tt.compact, err)
+				continue
+			} else if s := buf.String(); s != tt.indent {
+				GinkgoT().Errorf("Indent(%#q) = %#q, want %#q", tt.compact, s, tt.indent)
+			}
+		}
+	})
+	It("compact big", func() {
+
+		initBig()
+		var buf bytes.Buffer
+		if err := Compact(&buf, jsonBig); err != nil {
+			GinkgoT().Fatalf("Compact: %v", err)
+		}
+		b := buf.Bytes()
+		if !bytes.Equal(b, jsonBig) {
+			GinkgoT().Error("Compact(jsonBig) != jsonBig")
+			diff(GinkgoT(), b, jsonBig)
+			return
+		}
+	})
+	It("indent big", func() {
+
+		initBig()
+		var buf bytes.Buffer
+		if err := Indent(&buf, jsonBig, "", "\t"); err != nil {
+			GinkgoT().Fatalf("Indent1: %v", err)
+		}
+		b := buf.Bytes()
+		if len(b) == len(jsonBig) {
+			GinkgoT().Fatalf("Indent(jsonBig) did not get bigger")
+		}
+
+		var buf1 bytes.Buffer
+		if err := Indent(&buf1, b, "", "\t"); err != nil {
+			GinkgoT().Fatalf("Indent2: %v", err)
+		}
+		b1 := buf1.Bytes()
+		if !bytes.Equal(b1, b) {
+			GinkgoT().Error("Indent(Indent(jsonBig)) != Indent(jsonBig)")
+			diff(GinkgoT(), b1, b)
+			return
+		}
+
+		buf1.Reset()
+		if err := Compact(&buf1, b); err != nil {
+			GinkgoT().Fatalf("Compact: %v", err)
+		}
+		b1 = buf1.Bytes()
+		if !bytes.Equal(b1, jsonBig) {
+			GinkgoT().Error("Compact(Indent(jsonBig)) != jsonBig")
+			diff(GinkgoT(), b1, jsonBig)
+			return
+		}
+	})
+	It("indent errors", func() {
+
+		for i, tt := range indentErrorTests {
+			slice := make([]uint8, 0)
+			buf := bytes.NewBuffer(slice)
+			if err := Indent(buf, []uint8(tt.in), "", ""); err != nil {
+				if !reflect.DeepEqual(err, tt.err) {
+					GinkgoT().Errorf("#%d: Indent: %#v", i, err)
+					continue
+				}
+			}
+		}
+	})
+	It("next value big", func() {
+
+		initBig()
+		var scan scanner
+		item, rest, err := nextValue(jsonBig, &scan)
+		if err != nil {
+			GinkgoT().Fatalf("nextValue: %s", err)
+		}
+		if len(item) != len(jsonBig) || &item[0] != &jsonBig[0] {
+			GinkgoT().Errorf("invalid item: %d %d", len(item), len(jsonBig))
+		}
+		if len(rest) != 0 {
+			GinkgoT().Errorf("invalid rest: %d", len(rest))
+		}
+
+		item, rest, err = nextValue(append(jsonBig, "HELLO WORLD"...), &scan)
+		if err != nil {
+			GinkgoT().Fatalf("nextValue extra: %s", err)
+		}
+		if len(item) != len(jsonBig) {
+			GinkgoT().Errorf("invalid item: %d %d", len(item), len(jsonBig))
+		}
+		if string(rest) != "HELLO WORLD" {
+			GinkgoT().Errorf("invalid rest: %d", len(rest))
+		}
+	})
+})
 
 type example struct {
 	compact string
@@ -43,119 +186,6 @@ var ex1i = `[
 	-5e+2
 ]`
 
-func TestCompact(t *testing.T) {
-	var buf bytes.Buffer
-	for _, tt := range examples {
-		buf.Reset()
-		if err := Compact(&buf, []byte(tt.compact)); err != nil {
-			t.Errorf("Compact(%#q): %v", tt.compact, err)
-		} else if s := buf.String(); s != tt.compact {
-			t.Errorf("Compact(%#q) = %#q, want original", tt.compact, s)
-		}
-
-		buf.Reset()
-		if err := Compact(&buf, []byte(tt.indent)); err != nil {
-			t.Errorf("Compact(%#q): %v", tt.indent, err)
-			continue
-		} else if s := buf.String(); s != tt.compact {
-			t.Errorf("Compact(%#q) = %#q, want %#q", tt.indent, s, tt.compact)
-		}
-	}
-}
-
-func TestCompactSeparators(t *testing.T) {
-	// U+2028 and U+2029 should be escaped inside strings.
-	// They should not appear outside strings.
-	tests := []struct {
-		in, compact string
-	}{
-		{"{\"\u2028\": 1}", `{"\u2028":1}`},
-		{"{\"\u2029\" :2}", `{"\u2029":2}`},
-	}
-	for _, tt := range tests {
-		var buf bytes.Buffer
-		if err := Compact(&buf, []byte(tt.in)); err != nil {
-			t.Errorf("Compact(%q): %v", tt.in, err)
-		} else if s := buf.String(); s != tt.compact {
-			t.Errorf("Compact(%q) = %q, want %q", tt.in, s, tt.compact)
-		}
-	}
-}
-
-func TestIndent(t *testing.T) {
-	var buf bytes.Buffer
-	for _, tt := range examples {
-		buf.Reset()
-		if err := Indent(&buf, []byte(tt.indent), "", "\t"); err != nil {
-			t.Errorf("Indent(%#q): %v", tt.indent, err)
-		} else if s := buf.String(); s != tt.indent {
-			t.Errorf("Indent(%#q) = %#q, want original", tt.indent, s)
-		}
-
-		buf.Reset()
-		if err := Indent(&buf, []byte(tt.compact), "", "\t"); err != nil {
-			t.Errorf("Indent(%#q): %v", tt.compact, err)
-			continue
-		} else if s := buf.String(); s != tt.indent {
-			t.Errorf("Indent(%#q) = %#q, want %#q", tt.compact, s, tt.indent)
-		}
-	}
-}
-
-// Tests of a large random structure.
-
-func TestCompactBig(t *testing.T) {
-	initBig()
-	var buf bytes.Buffer
-	if err := Compact(&buf, jsonBig); err != nil {
-		t.Fatalf("Compact: %v", err)
-	}
-	b := buf.Bytes()
-	if !bytes.Equal(b, jsonBig) {
-		t.Error("Compact(jsonBig) != jsonBig")
-		diff(t, b, jsonBig)
-		return
-	}
-}
-
-func TestIndentBig(t *testing.T) {
-	initBig()
-	var buf bytes.Buffer
-	if err := Indent(&buf, jsonBig, "", "\t"); err != nil {
-		t.Fatalf("Indent1: %v", err)
-	}
-	b := buf.Bytes()
-	if len(b) == len(jsonBig) {
-		// jsonBig is compact (no unnecessary spaces);
-		// indenting should make it bigger
-		t.Fatalf("Indent(jsonBig) did not get bigger")
-	}
-
-	// should be idempotent
-	var buf1 bytes.Buffer
-	if err := Indent(&buf1, b, "", "\t"); err != nil {
-		t.Fatalf("Indent2: %v", err)
-	}
-	b1 := buf1.Bytes()
-	if !bytes.Equal(b1, b) {
-		t.Error("Indent(Indent(jsonBig)) != Indent(jsonBig)")
-		diff(t, b1, b)
-		return
-	}
-
-	// should get back to original
-	buf1.Reset()
-	if err := Compact(&buf1, b); err != nil {
-		t.Fatalf("Compact: %v", err)
-	}
-	b1 = buf1.Bytes()
-	if !bytes.Equal(b1, jsonBig) {
-		t.Error("Compact(Indent(jsonBig)) != jsonBig")
-		diff(t, b1, jsonBig)
-		return
-	}
-}
-
 type indentErrorTest struct {
 	in  string
 	err error
@@ -164,45 +194,6 @@ type indentErrorTest struct {
 var indentErrorTests = []indentErrorTest{
 	{`{"X": "foo", "Y"}`, &SyntaxError{"invalid character '}' after object key", 17}},
 	{`{"X": "foo" "Y": "bar"}`, &SyntaxError{"invalid character '\"' after object key:value pair", 13}},
-}
-
-func TestIndentErrors(t *testing.T) {
-	for i, tt := range indentErrorTests {
-		slice := make([]uint8, 0)
-		buf := bytes.NewBuffer(slice)
-		if err := Indent(buf, []uint8(tt.in), "", ""); err != nil {
-			if !reflect.DeepEqual(err, tt.err) {
-				t.Errorf("#%d: Indent: %#v", i, err)
-				continue
-			}
-		}
-	}
-}
-
-func TestNextValueBig(t *testing.T) {
-	initBig()
-	var scan scanner
-	item, rest, err := nextValue(jsonBig, &scan)
-	if err != nil {
-		t.Fatalf("nextValue: %s", err)
-	}
-	if len(item) != len(jsonBig) || &item[0] != &jsonBig[0] {
-		t.Errorf("invalid item: %d %d", len(item), len(jsonBig))
-	}
-	if len(rest) != 0 {
-		t.Errorf("invalid rest: %d", len(rest))
-	}
-
-	item, rest, err = nextValue(append(jsonBig, "HELLO WORLD"...), &scan)
-	if err != nil {
-		t.Fatalf("nextValue extra: %s", err)
-	}
-	if len(item) != len(jsonBig) {
-		t.Errorf("invalid item: %d %d", len(item), len(jsonBig))
-	}
-	if string(rest) != "HELLO WORLD" {
-		t.Errorf("invalid rest: %d", len(rest))
-	}
 }
 
 var benchScan scanner
@@ -215,7 +206,7 @@ func BenchmarkSkipValue(b *testing.B) {
 	b.SetBytes(int64(len(jsonBig)))
 }
 
-func diff(t *testing.T, a, b []byte) {
+func diff(t GinkgoTInterface, a, b []byte) {
 	for i := 0; ; i++ {
 		if i >= len(a) || i >= len(b) || a[i] != b[i] {
 			j := i - 10
@@ -234,8 +225,6 @@ func trim(b []byte) []byte {
 	}
 	return b
 }
-
-// Generate a random JSON object.
 
 var jsonBig []byte
 

--- a/forcejson/stream_test.go
+++ b/forcejson/stream_test.go
@@ -1,7 +1,3 @@
-// Copyright 2010 The Go Authors.  All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package forcejson
 
 import (
@@ -11,10 +7,141 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+
+	. "github.com/onsi/ginkgo"
 )
 
-// Test values for the stream test.
-// One of each JSON kind.
+var _ = Describe("Testing with Ginkgo", func() {
+	It("encoder", func() {
+
+		for i := 0; i <= len(streamTest); i++ {
+			var buf bytes.Buffer
+			enc := NewEncoder(&buf)
+			for j, v := range streamTest[0:i] {
+				if err := enc.Encode(v); err != nil {
+					GinkgoT().Fatalf("encode #%d: %v", j, err)
+				}
+			}
+			if have, want := buf.String(), nlines(streamEncoded, i); have != want {
+				GinkgoT().Errorf("encoding %d items: mismatch", i)
+				diff(GinkgoT(), []byte(have), []byte(want))
+				break
+			}
+		}
+	})
+	It("decoder", func() {
+
+		for i := 0; i <= len(streamTest); i++ {
+
+			var buf bytes.Buffer
+			for _, c := range nlines(streamEncoded, i) {
+				if c != '\n' {
+					buf.WriteRune(c)
+				}
+			}
+			out := make([]interface{}, i)
+			dec := NewDecoder(&buf)
+			for j := range out {
+				if err := dec.Decode(&out[j]); err != nil {
+					GinkgoT().Fatalf("decode #%d/%d: %v", j, i, err)
+				}
+			}
+			if !reflect.DeepEqual(out, streamTest[0:i]) {
+				GinkgoT().Errorf("decoding %d items: mismatch", i)
+				for j := range out {
+					if !reflect.DeepEqual(out[j], streamTest[j]) {
+						GinkgoT().Errorf("#%d: have %v want %v", j, out[j], streamTest[j])
+					}
+				}
+				break
+			}
+		}
+	})
+	It("decoder buffered", func() {
+
+		r := strings.NewReader(`{"Name": "Gopher"} extra `)
+		var m struct {
+			Name string
+		}
+		d := NewDecoder(r)
+		err := d.Decode(&m)
+		if err != nil {
+			GinkgoT().Fatal(err)
+		}
+		if m.Name != "Gopher" {
+			GinkgoT().Errorf("Name = %q; want Gopher", m.Name)
+		}
+		rest, err := ioutil.ReadAll(d.Buffered())
+		if err != nil {
+			GinkgoT().Fatal(err)
+		}
+		if g, w := string(rest), " extra "; g != w {
+			GinkgoT().Errorf("Remaining = %q; want %q", g, w)
+		}
+	})
+	It("raw message", func() {
+
+		var data struct {
+			X  float64
+			Id *RawMessage
+			Y  float32
+		}
+		const raw = `["\u0056",null]`
+		const msg = `{"X":0.1,"Id":["\u0056",null],"Y":0.2}`
+		err := Unmarshal([]byte(msg), &data)
+		if err != nil {
+			GinkgoT().Fatalf("Unmarshal: %v", err)
+		}
+		if string([]byte(*data.Id)) != raw {
+			GinkgoT().Fatalf("Raw mismatch: have %#q want %#q", []byte(*data.Id), raw)
+		}
+		b, err := Marshal(&data)
+		if err != nil {
+			GinkgoT().Fatalf("Marshal: %v", err)
+		}
+		if string(b) != msg {
+			GinkgoT().Fatalf("Marshal: have %#q want %#q", b, msg)
+		}
+	})
+	It("null raw message", func() {
+
+		var data struct {
+			X  float64
+			Id *RawMessage
+			Y  float32
+		}
+		data.Id = new(RawMessage)
+		const msg = `{"X":0.1,"Id":null,"Y":0.2}`
+		err := Unmarshal([]byte(msg), &data)
+		if err != nil {
+			GinkgoT().Fatalf("Unmarshal: %v", err)
+		}
+		if data.Id != nil {
+			GinkgoT().Fatalf("Raw mismatch: have non-nil, want nil")
+		}
+		b, err := Marshal(&data)
+		if err != nil {
+			GinkgoT().Fatalf("Marshal: %v", err)
+		}
+		if string(b) != msg {
+			GinkgoT().Fatalf("Marshal: have %#q want %#q", b, msg)
+		}
+	})
+	It("blocking", func() {
+
+		for _, enc := range blockingTests {
+			r, w := net.Pipe()
+			go w.Write([]byte(enc))
+			var val interface{}
+
+			if err := NewDecoder(r).Decode(&val); err != nil {
+				GinkgoT().Errorf("decoding %s: %v", enc, err)
+			}
+			r.Close()
+			w.Close()
+		}
+	})
+})
 var streamTest = []interface{}{
 	0.1,
 	"hello",
@@ -23,7 +150,7 @@ var streamTest = []interface{}{
 	false,
 	[]interface{}{"a", "b", "c"},
 	map[string]interface{}{"K": "Kelvin", "ß": "long s"},
-	3.14, // another value to make sure something can follow map
+	3.14,
 }
 
 var streamEncoded = `0.1
@@ -35,77 +162,6 @@ false
 {"ß":"long s","K":"Kelvin"}
 3.14
 `
-
-func TestEncoder(t *testing.T) {
-	for i := 0; i <= len(streamTest); i++ {
-		var buf bytes.Buffer
-		enc := NewEncoder(&buf)
-		for j, v := range streamTest[0:i] {
-			if err := enc.Encode(v); err != nil {
-				t.Fatalf("encode #%d: %v", j, err)
-			}
-		}
-		if have, want := buf.String(), nlines(streamEncoded, i); have != want {
-			t.Errorf("encoding %d items: mismatch", i)
-			diff(t, []byte(have), []byte(want))
-			break
-		}
-	}
-}
-
-func TestDecoder(t *testing.T) {
-	for i := 0; i <= len(streamTest); i++ {
-		// Use stream without newlines as input,
-		// just to stress the decoder even more.
-		// Our test input does not include back-to-back numbers.
-		// Otherwise stripping the newlines would
-		// merge two adjacent JSON values.
-		var buf bytes.Buffer
-		for _, c := range nlines(streamEncoded, i) {
-			if c != '\n' {
-				buf.WriteRune(c)
-			}
-		}
-		out := make([]interface{}, i)
-		dec := NewDecoder(&buf)
-		for j := range out {
-			if err := dec.Decode(&out[j]); err != nil {
-				t.Fatalf("decode #%d/%d: %v", j, i, err)
-			}
-		}
-		if !reflect.DeepEqual(out, streamTest[0:i]) {
-			t.Errorf("decoding %d items: mismatch", i)
-			for j := range out {
-				if !reflect.DeepEqual(out[j], streamTest[j]) {
-					t.Errorf("#%d: have %v want %v", j, out[j], streamTest[j])
-				}
-			}
-			break
-		}
-	}
-}
-
-func TestDecoderBuffered(t *testing.T) {
-	r := strings.NewReader(`{"Name": "Gopher"} extra `)
-	var m struct {
-		Name string
-	}
-	d := NewDecoder(r)
-	err := d.Decode(&m)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if m.Name != "Gopher" {
-		t.Errorf("Name = %q; want Gopher", m.Name)
-	}
-	rest, err := ioutil.ReadAll(d.Buffered())
-	if err != nil {
-		t.Fatal(err)
-	}
-	if g, w := string(rest), " extra "; g != w {
-		t.Errorf("Remaining = %q; want %q", g, w)
-	}
-}
 
 func nlines(s string, n int) string {
 	if n <= 0 {
@@ -121,75 +177,9 @@ func nlines(s string, n int) string {
 	return s
 }
 
-func TestRawMessage(t *testing.T) {
-	// TODO(rsc): Should not need the * in *RawMessage
-	var data struct {
-		X  float64
-		Id *RawMessage
-		Y  float32
-	}
-	const raw = `["\u0056",null]`
-	const msg = `{"X":0.1,"Id":["\u0056",null],"Y":0.2}`
-	err := Unmarshal([]byte(msg), &data)
-	if err != nil {
-		t.Fatalf("Unmarshal: %v", err)
-	}
-	if string([]byte(*data.Id)) != raw {
-		t.Fatalf("Raw mismatch: have %#q want %#q", []byte(*data.Id), raw)
-	}
-	b, err := Marshal(&data)
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
-	if string(b) != msg {
-		t.Fatalf("Marshal: have %#q want %#q", b, msg)
-	}
-}
-
-func TestNullRawMessage(t *testing.T) {
-	// TODO(rsc): Should not need the * in *RawMessage
-	var data struct {
-		X  float64
-		Id *RawMessage
-		Y  float32
-	}
-	data.Id = new(RawMessage)
-	const msg = `{"X":0.1,"Id":null,"Y":0.2}`
-	err := Unmarshal([]byte(msg), &data)
-	if err != nil {
-		t.Fatalf("Unmarshal: %v", err)
-	}
-	if data.Id != nil {
-		t.Fatalf("Raw mismatch: have non-nil, want nil")
-	}
-	b, err := Marshal(&data)
-	if err != nil {
-		t.Fatalf("Marshal: %v", err)
-	}
-	if string(b) != msg {
-		t.Fatalf("Marshal: have %#q want %#q", b, msg)
-	}
-}
-
 var blockingTests = []string{
 	`{"x": 1}`,
 	`[1, 2, 3]`,
-}
-
-func TestBlocking(t *testing.T) {
-	for _, enc := range blockingTests {
-		r, w := net.Pipe()
-		go w.Write([]byte(enc))
-		var val interface{}
-
-		// If Decode reads beyond what w.Write writes above,
-		// it will block, and the test will deadlock.
-		if err := NewDecoder(r).Decode(&val); err != nil {
-			t.Errorf("decoding %s: %v", enc, err)
-		}
-		r.Close()
-		w.Close()
-	}
 }
 
 func BenchmarkEncoderEncode(b *testing.B) {

--- a/forcejson/tagkey_test.go
+++ b/forcejson/tagkey_test.go
@@ -1,12 +1,35 @@
-// Copyright 2011 The Go Authors.  All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package forcejson
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo"
 )
+
+var _ = Describe("Testing with Ginkgo", func() {
+	It("struct tag object key", func() {
+
+		for _, tt := range structTagObjectKeyTests {
+			b, err := Marshal(tt.raw)
+			if err != nil {
+				GinkgoT().Fatalf("Marshal(%#q) failed: %v", tt.raw, err)
+			}
+			var f interface{}
+			err = Unmarshal(b, &f)
+			if err != nil {
+				GinkgoT().Fatalf("Unmarshal(%#q) failed: %v", b, err)
+			}
+			for i, v := range f.(map[string]interface{}) {
+				switch i {
+				case tt.key:
+					if s, ok := v.(string); !ok || s != tt.value {
+						GinkgoT().Fatalf("Unexpected value: %#q, want %v", s, tt.value)
+					}
+				default:
+					GinkgoT().Fatalf("Unexpected key: %#q, from %#q", i, b)
+				}
+			}
+		}
+	})
+})
 
 type basicLatin2xTag struct {
 	V string `force:"$%-/"`
@@ -37,11 +60,11 @@ type miscPlaneTag struct {
 }
 
 type percentSlashTag struct {
-	V string `force:"text/html%"` // http://golang.org/issue/2718
+	V string `force:"text/html%"`
 }
 
 type punctuationTag struct {
-	V string `force:"!#$%&()*+-./:<=>?@[]^_{|}~"` // http://golang.org/issue/3546
+	V string `force:"!#$%&()*+-./:<=>?@[]^_{|}~"`
 }
 
 type emptyTag struct {
@@ -88,28 +111,4 @@ var structTagObjectKeyTests = []struct {
 	{punctuationTag{"Union Rags"}, "Union Rags", "!#$%&()*+-./:<=>?@[]^_{|}~"},
 	{spaceTag{"Perreddu"}, "Perreddu", "With space"},
 	{unicodeTag{"Loukanikos"}, "Loukanikos", "Ελλάδα"},
-}
-
-func TestStructTagObjectKey(t *testing.T) {
-	for _, tt := range structTagObjectKeyTests {
-		b, err := Marshal(tt.raw)
-		if err != nil {
-			t.Fatalf("Marshal(%#q) failed: %v", tt.raw, err)
-		}
-		var f interface{}
-		err = Unmarshal(b, &f)
-		if err != nil {
-			t.Fatalf("Unmarshal(%#q) failed: %v", b, err)
-		}
-		for i, v := range f.(map[string]interface{}) {
-			switch i {
-			case tt.key:
-				if s, ok := v.(string); !ok || s != tt.value {
-					t.Fatalf("Unexpected value: %#q, want %v", s, tt.value)
-				}
-			default:
-				t.Fatalf("Unexpected key: %#q, from %#q", i, b)
-			}
-		}
-	}
 }

--- a/forcejson/tags_test.go
+++ b/forcejson/tags_test.go
@@ -1,28 +1,27 @@
-// Copyright 2011 The Go Authors.  All rights reserved.
-// Use of this source code is governed by a BSD-style
-// license that can be found in the LICENSE file.
-
 package forcejson
 
 import (
-	"testing"
+	. "github.com/onsi/ginkgo"
 )
 
-func TestTagParsing(t *testing.T) {
-	name, opts := parseTag("field,foobar,foo")
-	if name != "field" {
-		t.Fatalf("name = %q, want field", name)
-	}
-	for _, tt := range []struct {
-		opt  string
-		want bool
-	}{
-		{"foobar", true},
-		{"foo", true},
-		{"bar", false},
-	} {
-		if opts.Contains(tt.opt) != tt.want {
-			t.Errorf("Contains(%q) = %v", tt.opt, !tt.want)
+var _ = Describe("Testing with Ginkgo", func() {
+	It("tag parsing", func() {
+
+		name, opts := parseTag("field,foobar,foo")
+		if name != "field" {
+			GinkgoT().Fatalf("name = %q, want field", name)
 		}
-	}
-}
+		for _, tt := range []struct {
+			opt  string
+			want bool
+		}{
+			{"foobar", true},
+			{"foo", true},
+			{"bar", false},
+		} {
+			if opts.Contains(tt.opt) != tt.want {
+				GinkgoT().Errorf("Contains(%q) = %v", tt.opt, !tt.want)
+			}
+		}
+	})
+})

--- a/sobjects/sobjects_suite_test.go
+++ b/sobjects/sobjects_suite_test.go
@@ -1,0 +1,13 @@
+package sobjects_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+func TestSobjects(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Sobjects Suite")
+}


### PR DESCRIPTION
This change converts all go-force tests to [Ginkgo](https://github.com/onsi/ginkgo). This makes development easier and more consistent.