### PR TITLE
Get multiple sfids

### DIFF
--- a/force/api.go
+++ b/force/api.go
@@ -188,6 +188,7 @@ type RestAPI interface {
 	GetLimits() (*Limits, error)
 	GetSObject(id string, fields []string, out SObject) (err error)
 	GetSObjectByExternalId(externalKey, externalId string, fields []string, out SObject) (statusCode int, err error)
+	GetSFIDsByExternalId(apiName, externalKey, externalId string) ([]string, int, error)
 	Query(query string, out interface{}) (err error)
 	QueryAll(query string, out interface{}) (err error)
 	QueryNext(uri string, out interface{}) (err error)

--- a/force/client_test.go
+++ b/force/client_test.go
@@ -1,44 +1,16 @@
 package force_test
 
 import (
-	"bytes"
-	"io/ioutil"
-	"net/http"
 	"net/url"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/opendoor-labs/go-force/force"
 	"github.com/opendoor-labs/go-force/force/forcefakes"
 	"github.com/opendoor-labs/go-force/sobjects"
 )
 
 const oauthRespBody = `{"access_token": "at", "instance_url": "iu", "id": "anid", "issued_at": "ia", "signature": "sig"}`
-
-func newResponse(body string) (resp *http.Response) {
-	return &http.Response{
-		Status:     "200 OK",
-		StatusCode: 200,
-		Proto:      "HTTP/1.0",
-		ProtoMajor: 1,
-		ProtoMinor: 0,
-		Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
-	}
-}
-
-func createForceApi(httpClient *forcefakes.FakeHttpClient) (*force.ForceApi, error) {
-	authResp := newResponse(oauthRespBody)
-	httpClient.DoReturnsOnCall(0, authResp, nil)
-
-	apiResourceResp := newResponse(`{"aresourceKey": "aResourceValue"}`)
-	httpClient.DoReturnsOnCall(1, apiResourceResp, nil)
-
-	apiSObjectsResp := newResponse(`{"ASObject": {"name": "TheName"}}`)
-	httpClient.DoReturnsOnCall(2, apiSObjectsResp, nil)
-
-	return force.Create("", "", "", "", "", "", "", httpClient)
-}
 
 var _ = Describe("Client", func() {
 	Describe("Get", func() {
@@ -48,7 +20,7 @@ var _ = Describe("Client", func() {
 			forceApi, err := createForceApi(&httpClient)
 			Expect(err).NotTo(HaveOccurred())
 
-			apiSObjectsResp := newResponse(`{"Id": "SFID-123"}`)
+			apiSObjectsResp := NewFakeResponse(`{"Id": "SFID-123"}`, 200)
 			httpClient.DoReturnsOnCall(3, apiSObjectsResp, nil)
 
 			params := url.Values{"fields": []string{"Id"}}

--- a/force/client_test.go
+++ b/force/client_test.go
@@ -1,0 +1,63 @@
+package force_test
+
+import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/opendoor-labs/go-force/force"
+	"github.com/opendoor-labs/go-force/force/forcefakes"
+	"github.com/opendoor-labs/go-force/sobjects"
+)
+
+const oauthRespBody = `{"access_token": "at", "instance_url": "iu", "id": "anid", "issued_at": "ia", "signature": "sig"}`
+
+func newResponse(body string) (resp *http.Response) {
+	return &http.Response{
+		Status:     "200 OK",
+		StatusCode: 200,
+		Proto:      "HTTP/1.0",
+		ProtoMajor: 1,
+		ProtoMinor: 0,
+		Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+	}
+}
+
+func createForceApi(httpClient *forcefakes.FakeHttpClient) (*force.ForceApi, error) {
+	authResp := newResponse(oauthRespBody)
+	httpClient.DoReturnsOnCall(0, authResp, nil)
+
+	apiResourceResp := newResponse(`{"aresourceKey": "aResourceValue"}`)
+	httpClient.DoReturnsOnCall(1, apiResourceResp, nil)
+
+	apiSObjectsResp := newResponse(`{"ASObject": {"name": "TheName"}}`)
+	httpClient.DoReturnsOnCall(2, apiSObjectsResp, nil)
+
+	return force.Create("", "", "", "", "", "", "", httpClient)
+}
+
+var _ = Describe("Client", func() {
+	Describe("Get", func() {
+		It("should unmarshal a resource", func() {
+			httpClient := forcefakes.FakeHttpClient{}
+
+			forceApi, err := createForceApi(&httpClient)
+			Expect(err).NotTo(HaveOccurred())
+
+			apiSObjectsResp := newResponse(`{"Id": "SFID-123"}`)
+			httpClient.DoReturnsOnCall(3, apiSObjectsResp, nil)
+
+			params := url.Values{"fields": []string{"Id"}}
+			sobj := sobjects.BaseSObject{}
+
+			status, err := forceApi.Get("/sobjects/path", params, &sobj)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(status).To(Equal(200))
+			Expect(sobj.Id).To(Equal("SFID-123"))
+		})
+	})
+})

--- a/force/force.go
+++ b/force/force.go
@@ -51,6 +51,7 @@ func Create(version, clientId, clientSecret, userName, password, securityToken,
 	if err != nil {
 		return nil, err
 	}
+
 	err = forceApi.getApiSObjects()
 	if err != nil {
 		return nil, err

--- a/force/force_suite_test.go
+++ b/force/force_suite_test.go
@@ -1,11 +1,44 @@
 package force_test
 
 import (
+	"bytes"
+	"io/ioutil"
+	"net/http"
 	"testing"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/opendoor-labs/go-force/force"
+	"github.com/opendoor-labs/go-force/force/forcefakes"
 )
+
+const FakeOauthRespBody = `{"access_token": "at", "instance_url": "iu", "id": "anid", "issued_at": "ia", "signature": "sig"}`
+
+func NewFakeResponse(body string, statusCode int) (resp *http.Response) {
+	return &http.Response{
+		StatusCode: statusCode,
+		Proto:      "HTTP/1.0",
+		Body:       ioutil.NopCloser(bytes.NewBufferString(body)),
+	}
+}
+
+func createForceApi(httpClient *forcefakes.FakeHttpClient) (*force.ForceApi, error) {
+	// The first 3 http Do() calls are made by Create to setup Auth +
+	// resources.  Users of the the returned ForceApi instance with the
+	// mocked httpClient that's returned should mock return calls starting
+	// at 3.
+
+	authResp := NewFakeResponse(FakeOauthRespBody, 200)
+	httpClient.DoReturnsOnCall(0, authResp, nil)
+
+	apiResourceResp := NewFakeResponse(`{"sobjects": "sobjects-resources"}`, 200)
+	httpClient.DoReturnsOnCall(1, apiResourceResp, nil)
+
+	apiSObjectsResp := NewFakeResponse(`{"sobjects": [{"name": "APIName", "urls": {"sobject": "the/url"}}]}`, 200)
+	httpClient.DoReturnsOnCall(2, apiSObjectsResp, nil)
+
+	return force.Create("", "", "", "", "", "", "", httpClient)
+}
 
 func TestForce(t *testing.T) {
 	RegisterFailHandler(Fail)

--- a/force/forcefakes/fake_rest_api.go
+++ b/force/forcefakes/fake_rest_api.go
@@ -139,6 +139,23 @@ type FakeRestAPI struct {
 		result1 int
 		result2 error
 	}
+	GetSFIDsByExternalIdStub        func(apiName, externalKey, externalId string) ([]string, int, error)
+	getSFIDsByExternalIdMutex       sync.RWMutex
+	getSFIDsByExternalIdArgsForCall []struct {
+		apiName     string
+		externalKey string
+		externalId  string
+	}
+	getSFIDsByExternalIdReturns struct {
+		result1 []string
+		result2 int
+		result3 error
+	}
+	getSFIDsByExternalIdReturnsOnCall map[int]struct {
+		result1 []string
+		result2 int
+		result3 error
+	}
 	QueryStub        func(query string, out interface{}) (err error)
 	queryMutex       sync.RWMutex
 	queryArgsForCall []struct {
@@ -751,6 +768,62 @@ func (fake *FakeRestAPI) GetSObjectByExternalIdReturnsOnCall(i int, result1 int,
 	}{result1, result2}
 }
 
+func (fake *FakeRestAPI) GetSFIDsByExternalId(apiName string, externalKey string, externalId string) ([]string, int, error) {
+	fake.getSFIDsByExternalIdMutex.Lock()
+	ret, specificReturn := fake.getSFIDsByExternalIdReturnsOnCall[len(fake.getSFIDsByExternalIdArgsForCall)]
+	fake.getSFIDsByExternalIdArgsForCall = append(fake.getSFIDsByExternalIdArgsForCall, struct {
+		apiName     string
+		externalKey string
+		externalId  string
+	}{apiName, externalKey, externalId})
+	fake.recordInvocation("GetSFIDsByExternalId", []interface{}{apiName, externalKey, externalId})
+	fake.getSFIDsByExternalIdMutex.Unlock()
+	if fake.GetSFIDsByExternalIdStub != nil {
+		return fake.GetSFIDsByExternalIdStub(apiName, externalKey, externalId)
+	}
+	if specificReturn {
+		return ret.result1, ret.result2, ret.result3
+	}
+	return fake.getSFIDsByExternalIdReturns.result1, fake.getSFIDsByExternalIdReturns.result2, fake.getSFIDsByExternalIdReturns.result3
+}
+
+func (fake *FakeRestAPI) GetSFIDsByExternalIdCallCount() int {
+	fake.getSFIDsByExternalIdMutex.RLock()
+	defer fake.getSFIDsByExternalIdMutex.RUnlock()
+	return len(fake.getSFIDsByExternalIdArgsForCall)
+}
+
+func (fake *FakeRestAPI) GetSFIDsByExternalIdArgsForCall(i int) (string, string, string) {
+	fake.getSFIDsByExternalIdMutex.RLock()
+	defer fake.getSFIDsByExternalIdMutex.RUnlock()
+	return fake.getSFIDsByExternalIdArgsForCall[i].apiName, fake.getSFIDsByExternalIdArgsForCall[i].externalKey, fake.getSFIDsByExternalIdArgsForCall[i].externalId
+}
+
+func (fake *FakeRestAPI) GetSFIDsByExternalIdReturns(result1 []string, result2 int, result3 error) {
+	fake.GetSFIDsByExternalIdStub = nil
+	fake.getSFIDsByExternalIdReturns = struct {
+		result1 []string
+		result2 int
+		result3 error
+	}{result1, result2, result3}
+}
+
+func (fake *FakeRestAPI) GetSFIDsByExternalIdReturnsOnCall(i int, result1 []string, result2 int, result3 error) {
+	fake.GetSFIDsByExternalIdStub = nil
+	if fake.getSFIDsByExternalIdReturnsOnCall == nil {
+		fake.getSFIDsByExternalIdReturnsOnCall = make(map[int]struct {
+			result1 []string
+			result2 int
+			result3 error
+		})
+	}
+	fake.getSFIDsByExternalIdReturnsOnCall[i] = struct {
+		result1 []string
+		result2 int
+		result3 error
+	}{result1, result2, result3}
+}
+
 func (fake *FakeRestAPI) Query(query string, out interface{}) (err error) {
 	fake.queryMutex.Lock()
 	ret, specificReturn := fake.queryReturnsOnCall[len(fake.queryArgsForCall)]
@@ -1068,6 +1141,8 @@ func (fake *FakeRestAPI) Invocations() map[string][][]interface{} {
 	defer fake.getSObjectMutex.RUnlock()
 	fake.getSObjectByExternalIdMutex.RLock()
 	defer fake.getSObjectByExternalIdMutex.RUnlock()
+	fake.getSFIDsByExternalIdMutex.RLock()
+	defer fake.getSFIDsByExternalIdMutex.RUnlock()
 	fake.queryMutex.RLock()
 	defer fake.queryMutex.RUnlock()
 	fake.queryAllMutex.RLock()

--- a/force/priv_sobjects_test.go
+++ b/force/priv_sobjects_test.go
@@ -1,0 +1,156 @@
+package force
+
+import (
+	"math/rand"
+
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	"github.com/opendoor-labs/go-force/sobjects"
+)
+
+var _ = Describe("Testing with Ginkgo", func() {
+	It("describe sobjects", func() {
+
+		forceAPI := createTest()
+		objects, err := forceAPI.DescribeSObjects()
+		if err != nil {
+			GinkgoT().Fatal("Failed to retrieve SObjects", err)
+		}
+		GinkgoT().Logf("SObjects for Account Retrieved: %+v", objects)
+	})
+	It("describe s object", func() {
+
+		forceApi := createTest()
+		acc := &sobjects.Account{}
+
+		desc, err := forceApi.DescribeSObject(acc)
+		if err != nil {
+			GinkgoT().Fatalf("Cannot retrieve SObject Description for Account SObject: %v", err)
+		}
+		GinkgoT().Logf("SObject Description for Account Retrieved: %+v", desc)
+	})
+	It("get s object", func() {
+
+		forceApi := createTest()
+
+		acc := &sobjects.Account{}
+
+		err := forceApi.GetSObject(AccountId, nil, acc)
+		if err != nil {
+			GinkgoT().Fatalf("Cannot retrieve SObject Account: %v", err)
+		}
+		GinkgoT().Logf("SObject Account Retrieved: %+v", acc)
+
+		customObject := &CustomSObject{}
+
+		err = forceApi.GetSObject(CustomObjectId, nil, customObject)
+		if err != nil {
+			GinkgoT().Fatalf("Cannot retrieve SObject CustomObject: %v", err)
+		}
+		GinkgoT().Logf("SObject CustomObject Retrieved: %+v", customObject)
+
+		fields := []string{"Name", "Id"}
+
+		accFields := &sobjects.Account{}
+
+		err = forceApi.GetSObject(AccountId, fields, accFields)
+		if err != nil {
+			GinkgoT().Fatalf("Cannot retrieve SObject Account fields: %v", err)
+		}
+		GinkgoT().Logf("SObject Account Name and Id Retrieved: %+v", accFields)
+	})
+	It("update s object", func() {
+
+		forceApi := createTest()
+
+		rand.Seed(time.Now().UTC().UnixNano())
+		someText := randomString(10)
+
+		acc := &sobjects.Account{}
+		acc.Name = someText
+
+		err := forceApi.UpdateSObject(AccountId, acc)
+		if err != nil {
+			GinkgoT().Fatalf("Cannot update SObject Account: %v", err)
+		}
+
+		err = forceApi.GetSObject(AccountId, nil, acc)
+		if err != nil {
+			GinkgoT().Fatalf("Cannot retrieve SObject Account: %v", err)
+		}
+
+		if acc.Name != someText {
+			GinkgoT().Fatalf("Update SObject Account failed. Failed to persist.")
+		}
+		GinkgoT().Logf("Updated SObject Account: %+v", acc)
+	})
+	It("insert delete s object", func() {
+
+		forceApi := createTest()
+		objectId := insertSObject(forceApi, GinkgoT())
+		deleteSObject(forceApi, GinkgoT(), objectId)
+	})
+})
+
+const (
+	AccountId      = "001i000000RxW18"
+	CustomObjectId = "a00i0000009SPer"
+)
+
+type CustomSObject struct {
+	sobjects.BaseSObject
+	Active    bool   `force:"Active__c"`
+	AccountId string `force:"Account__c"`
+}
+
+func (t *CustomSObject) APIName() string {
+	return "CustomObject__c"
+}
+
+func insertSObject(forceApi *ForceApi, t GinkgoTInterface) string {
+
+	rand.Seed(time.Now().UTC().UnixNano())
+	someText := randomString(10)
+
+	acc := &sobjects.Account{}
+	acc.Name = someText
+
+	resp, err := forceApi.InsertSObject(acc)
+	if err != nil {
+		t.Fatalf("Insert SObject Account failed: %v", err)
+	}
+
+	if len(resp.Id) == 0 {
+		t.Fatalf("Insert SObject Account failed to return Id: %+v", resp)
+	}
+
+	return resp.Id
+}
+
+func deleteSObject(forceApi *ForceApi, t GinkgoTInterface, id string) {
+
+	acc := &sobjects.Account{}
+
+	err := forceApi.DeleteSObject(id, acc)
+	if err != nil {
+		t.Fatalf("Delete SObject Account failed: %v", err)
+	}
+
+	err = forceApi.GetSObject(id, nil, acc)
+	if err == nil {
+		t.Fatalf("Delete SObject Account failed, was able to retrieve deleted object: %+v", acc)
+	}
+}
+
+func randomString(l int) string {
+	bytes := make([]byte, l)
+	for i := 0; i < l; i++ {
+		bytes[i] = byte(randInt(65, 90))
+	}
+	return string(bytes)
+}
+
+func randInt(min int, max int) int {
+	return min + rand.Intn(max-min)
+}

--- a/force/sobjects.go
+++ b/force/sobjects.go
@@ -160,7 +160,7 @@ func (forceApi *ForceApi) GetSFIDsByExternalId(apiName, externalKey, externalId 
 		return forceApi.getMultipleSFIDs(uri, params)
 	}
 
-	return []string{}, statusCode, err
+	return nil, statusCode, err
 }
 
 func (forceApi *ForceApi) GetSObjectByExternalId(externalKey, externalId string, fields []string, out SObject) (statusCode int, err error) {

--- a/force/sobjects.go
+++ b/force/sobjects.go
@@ -131,6 +131,9 @@ func (forceApi *ForceApi) getSingleSFID(uri string, params url.Values) (string, 
 }
 
 func (forceApi *ForceApi) getMultipleSFIDs(uri string, params url.Values) ([]string, int, error) {
+	// We don't have access to the json that was returned, so make the
+	// same call as was made in getSingleSFID() passing in a slice to
+	// unmarshal into.
 	uris := []string{}
 	statusCode, err := forceApi.Get(uri, params, &uris)
 	if err != nil {
@@ -153,9 +156,6 @@ func (forceApi *ForceApi) GetSFIDsByExternalId(apiName, externalKey, externalId 
 	// Status code 300 (StatusMultipleChoices) is returned when an external
 	// ID exists in more than one record. The response body contains the
 	// list of matching records.
-
-	// We don't have access to the json that was returned, so make the
-	// same call passing in a slice to unmarshal into.
 	if statusCode == http.StatusMultipleChoices {
 		return forceApi.getMultipleSFIDs(uri, params)
 	}

--- a/force/sobjects.go
+++ b/force/sobjects.go
@@ -137,7 +137,7 @@ func (forceApi *ForceApi) getMultipleSFIDs(uri string, params url.Values) ([]str
 	uris := []string{}
 	statusCode, err := forceApi.Get(uri, params, &uris)
 	if err != nil {
-		return []string{}, statusCode, err
+		return nil, statusCode, err
 	}
 
 	return idsFromURIs(uris), statusCode, nil

--- a/force/sobjects.go
+++ b/force/sobjects.go
@@ -3,6 +3,7 @@ package force
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"net/url"
 	"strings"
 
@@ -134,9 +135,14 @@ func (forceApi *ForceApi) GetSFIDsByExternalId(apiName, externalKey, externalId 
 		return []string{sobj.Id}, statusCode, nil
 	}
 
-	if statusCode != 300 {
+	if statusCode != http.StatusMultipleChoices {
 		return []string{}, statusCode, err
 	}
+
+	// https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/errorcodes.htm
+	// Status code 300 (StatusMultipleChoices) is returned when an external
+	// ID exists in more than one record. The response body contains the
+	// list of matching records.
 
 	// We don't have access to the json that was returned, so make the
 	// same call passing in a slice to unmarshal into.

--- a/force/sobjects_test.go
+++ b/force/sobjects_test.go
@@ -59,5 +59,19 @@ var _ = Describe("Sobjects", func() {
 				Expect(status).To(Equal(300))
 			})
 		})
+
+		Context("request failed", func() {
+			It("should return the statusCode and the error", func() {
+				apiSObjectsResp := NewFakeResponse(multiURISObjectResponse, 400)
+				httpClient.DoReturnsOnCall(3, apiSObjectsResp, nil)
+				apiSObjectsResp = NewFakeResponse(multiURISObjectResponse, 400)
+				httpClient.DoReturnsOnCall(4, apiSObjectsResp, nil)
+
+				actualIds, status, err := forceApi.GetSFIDsByExternalId("APIName", "ExKey", "ExId-123")
+				Expect(err).To(HaveOccurred())
+				Expect(status).To(Equal(400))
+				Expect(actualIds).To(Equal([]string{}))
+			})
+		})
 	})
 })

--- a/force/sobjects_test.go
+++ b/force/sobjects_test.go
@@ -1,156 +1,63 @@
-package force
+package force_test
 
 import (
-	"math/rand"
-
-	"time"
+	"fmt"
 
 	. "github.com/onsi/ginkgo"
-	"github.com/opendoor-labs/go-force/sobjects"
+	. "github.com/onsi/gomega"
+
+	"github.com/opendoor-labs/go-force/force"
+	"github.com/opendoor-labs/go-force/force/forcefakes"
 )
 
-var _ = Describe("Testing with Ginkgo", func() {
-	It("describe sobjects", func() {
+const sobjId_1 = "00Q29000004RbVPEA0"
+const sobjId_2 = "00Q29000004RbVUEA0"
+const baseLeadURI = "/services/data/v40.0/sobjects/Lead"
 
-		forceAPI := createTest()
-		objects, err := forceAPI.DescribeSObjects()
-		if err != nil {
-			GinkgoT().Fatal("Failed to retrieve SObjects", err)
-		}
-		GinkgoT().Logf("SObjects for Account Retrieved: %+v", objects)
+var multiURISObjectResponse = fmt.Sprintf(`["%s/%s","%s/%s"]`, baseLeadURI, sobjId_1, baseLeadURI, sobjId_2)
+
+var _ = Describe("Sobjects", func() {
+	var httpClient forcefakes.FakeHttpClient
+	var forceApi *force.ForceApi
+
+	BeforeEach(func() {
+		httpClient = forcefakes.FakeHttpClient{}
+
+		var err error
+		forceApi, err = createForceApi(&httpClient)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(forceApi).NotTo(BeNil())
 	})
-	It("describe s object", func() {
 
-		forceApi := createTest()
-		acc := &sobjects.Account{}
+	Describe("GetSFIDsByExternalId", func() {
+		Context("a single object is returned", func() {
+			It("should return a slice with one ID", func() {
+				apiSObjectsResp := NewFakeResponse(`{"Id": "SFID-123"}`, 200)
+				httpClient.DoReturnsOnCall(3, apiSObjectsResp, nil)
 
-		desc, err := forceApi.DescribeSObject(acc)
-		if err != nil {
-			GinkgoT().Fatalf("Cannot retrieve SObject Description for Account SObject: %v", err)
-		}
-		GinkgoT().Logf("SObject Description for Account Retrieved: %+v", desc)
-	})
-	It("get s object", func() {
+				actualIds, status, err := forceApi.GetSFIDsByExternalId("APIName", "ExKey", "ExId-123")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(actualIds).To(Equal([]string{"SFID-123"}))
+				Expect(status).To(Equal(200))
+			})
+		})
 
-		forceApi := createTest()
+		Context("multiple objects are returned", func() {
+			It("should return a slice with the IDs", func() {
+				// When there are multiple results, the same call is made
+				// twice, the first call attempts unmarshalling into the SObject,
+				// when a 300 is detected, the call is made again passing into it
+				// a slice for unmarshalling multiple URIs.
+				apiSObjectsResp := NewFakeResponse(multiURISObjectResponse, 300)
+				httpClient.DoReturnsOnCall(3, apiSObjectsResp, nil)
+				apiSObjectsResp = NewFakeResponse(multiURISObjectResponse, 300)
+				httpClient.DoReturnsOnCall(4, apiSObjectsResp, nil)
 
-		acc := &sobjects.Account{}
-
-		err := forceApi.GetSObject(AccountId, nil, acc)
-		if err != nil {
-			GinkgoT().Fatalf("Cannot retrieve SObject Account: %v", err)
-		}
-		GinkgoT().Logf("SObject Account Retrieved: %+v", acc)
-
-		customObject := &CustomSObject{}
-
-		err = forceApi.GetSObject(CustomObjectId, nil, customObject)
-		if err != nil {
-			GinkgoT().Fatalf("Cannot retrieve SObject CustomObject: %v", err)
-		}
-		GinkgoT().Logf("SObject CustomObject Retrieved: %+v", customObject)
-
-		fields := []string{"Name", "Id"}
-
-		accFields := &sobjects.Account{}
-
-		err = forceApi.GetSObject(AccountId, fields, accFields)
-		if err != nil {
-			GinkgoT().Fatalf("Cannot retrieve SObject Account fields: %v", err)
-		}
-		GinkgoT().Logf("SObject Account Name and Id Retrieved: %+v", accFields)
-	})
-	It("update s object", func() {
-
-		forceApi := createTest()
-
-		rand.Seed(time.Now().UTC().UnixNano())
-		someText := randomString(10)
-
-		acc := &sobjects.Account{}
-		acc.Name = someText
-
-		err := forceApi.UpdateSObject(AccountId, acc)
-		if err != nil {
-			GinkgoT().Fatalf("Cannot update SObject Account: %v", err)
-		}
-
-		err = forceApi.GetSObject(AccountId, nil, acc)
-		if err != nil {
-			GinkgoT().Fatalf("Cannot retrieve SObject Account: %v", err)
-		}
-
-		if acc.Name != someText {
-			GinkgoT().Fatalf("Update SObject Account failed. Failed to persist.")
-		}
-		GinkgoT().Logf("Updated SObject Account: %+v", acc)
-	})
-	It("insert delete s object", func() {
-
-		forceApi := createTest()
-		objectId := insertSObject(forceApi, GinkgoT())
-		deleteSObject(forceApi, GinkgoT(), objectId)
+				actualIds, status, err := forceApi.GetSFIDsByExternalId("APIName", "ExKey", "ExId-123")
+				Expect(err).NotTo(HaveOccurred())
+				Expect(actualIds).To(Equal([]string{sobjId_1, sobjId_2}))
+				Expect(status).To(Equal(300))
+			})
+		})
 	})
 })
-
-const (
-	AccountId      = "001i000000RxW18"
-	CustomObjectId = "a00i0000009SPer"
-)
-
-type CustomSObject struct {
-	sobjects.BaseSObject
-	Active    bool   `force:"Active__c"`
-	AccountId string `force:"Account__c"`
-}
-
-func (t *CustomSObject) APIName() string {
-	return "CustomObject__c"
-}
-
-func insertSObject(forceApi *ForceApi, t GinkgoTInterface) string {
-
-	rand.Seed(time.Now().UTC().UnixNano())
-	someText := randomString(10)
-
-	acc := &sobjects.Account{}
-	acc.Name = someText
-
-	resp, err := forceApi.InsertSObject(acc)
-	if err != nil {
-		t.Fatalf("Insert SObject Account failed: %v", err)
-	}
-
-	if len(resp.Id) == 0 {
-		t.Fatalf("Insert SObject Account failed to return Id: %+v", resp)
-	}
-
-	return resp.Id
-}
-
-func deleteSObject(forceApi *ForceApi, t GinkgoTInterface, id string) {
-
-	acc := &sobjects.Account{}
-
-	err := forceApi.DeleteSObject(id, acc)
-	if err != nil {
-		t.Fatalf("Delete SObject Account failed: %v", err)
-	}
-
-	err = forceApi.GetSObject(id, nil, acc)
-	if err == nil {
-		t.Fatalf("Delete SObject Account failed, was able to retrieve deleted object: %+v", acc)
-	}
-}
-
-func randomString(l int) string {
-	bytes := make([]byte, l)
-	for i := 0; i < l; i++ {
-		bytes[i] = byte(randInt(65, 90))
-	}
-	return string(bytes)
-}
-
-func randInt(min int, max int) int {
-	return min + rand.Intn(max-min)
-}

--- a/force/sobjects_test.go
+++ b/force/sobjects_test.go
@@ -70,7 +70,7 @@ var _ = Describe("Sobjects", func() {
 				actualIds, status, err := forceApi.GetSFIDsByExternalId("APIName", "ExKey", "ExId-123")
 				Expect(err).To(HaveOccurred())
 				Expect(status).To(Equal(400))
-				Expect(actualIds).To(Equal([]string{}))
+				Expect(actualIds).To(BeNil())
 			})
 		})
 	})


### PR DESCRIPTION
When multiple SFDC records correspond to the same ExternalId, an array of URIs is returned, making resolution of objects challenging for clients. This change adds `GetSFIDsByExternalId` which will always return a slice of Salesforce IDs corresponding to the external id. If there is only one corresponding SFDC object, a slice with the single ID will be returned.